### PR TITLE
Update the regex for csrf

### DIFF
--- a/runner_benchmark/utils.py
+++ b/runner_benchmark/utils.py
@@ -41,7 +41,7 @@ class QuestionnaireMixins:
         return response
 
 
-CSRF_REGEX = re.compile(r'<input id="csrf_token" name="csrf_token" type="hidden" value="(.+?)"/>')
+CSRF_REGEX = re.compile(r'<input id=csrf_token name=csrf_token type=hidden value=(.+?)>')
 
 
 def _extract_csrf_token(html):


### PR DESCRIPTION
Ian noticed some issues when running this against v3. 

I'm not entirely sure why this has changed, but the included regex seems to work.