### PR TITLE
Update claims to match runner changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ dmypy.json
 
 # Request logs
 *.har
+
+# intellij
+.idea/

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ To run a benchmark, use:
 
 ```bash
 pipenv install
-pipenv run ./run.sh <EQ_ID> <FORM_TYPE>
+pipenv run ./run.sh <SCHEMA_NAME> <HOST: Optional>
 ```
 e.g.
 ```
-pipenv run ./run.sh test mutually_exclusive
+pipenv run ./run.sh test_mutually_exclusive
 ```
 
 This will run 1 minute of locust requests with 1 user and no wait time between requests.
@@ -34,13 +34,13 @@ If you'd like to run locust on its own, you can use the following commands
 For the web interface:
 
 ```bash
-EQ_ID=test FORM_TYPE=mutually_exclusive pipenv run locust -f runner_benchmark/har_replay_test.py --host=http://localhost:5000
+SCHEMA_NAME=test_hub_and_spoke HOST=http://localhost:5000 pipenv run locust -f runner_benchmark/har_replay_test.py
 ```
 
 For a command line interface ( with output CSV file ):
 
 ```bash
-EQ_ID=test FORM_TYPE=mutually_exclusive pipenv run locust -f runner_benchmark/har_replay_test.py --host=http://localhost:5000 --no-web -t 1m -c 100 -r 10 --csv=output
+SCHEMA_NAME=test_hub_and_spoke HOST=http://localhost:5000 pipenv run locust -f runner_benchmark/har_replay_test.py --no-web -t 1m -c 100 -r 10 --csv=output
 ```
 
 ## Configuration
@@ -49,8 +49,8 @@ The following environment variables can be used to configure the locust test:
 
 - `HAR_FILEPATH` - The filepath of the HAR file relative to the base project directory
   - Defaults to `requests.har`
-- `EQ_ID` - The eq_id of the schema being tested.
-- `FORM_TYPE` - The form_type of the schema being tested.
+- `SCHEMA_NAME` - The name of the schema being tested.
+- `HOST` - The host name the benchmark is run against.
 - `USER_WAIT_TIME_MIN_SECONDS` - The minimum delay between each user's GET requests
   - defaults to zero
 - `USER_WAIT_TIME_MAX_SECONDS` - The maximum delay between each user's GET requests

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo "Running Locust benchmark"
-EQ_ID=${1} FORM_TYPE=${2} locust -f runner_benchmark/har_replay_test.py --host=http://localhost:5000 --no-web -c 1 -r 1 --csv=output -t 1m -L WARNING
+SCHEMA_NAME="${1}" HOST="${2:-http://localhost:5000}" pipenv run locust -f runner_benchmark/har_replay_test.py --no-web -t 1m -c 100 -r 10 --csv=output --no-web -c 1 -r 1 --csv=output -t 1m -L WARNING
 ./scripts/output_processor.py

--- a/runner_benchmark/har_parser.py
+++ b/runner_benchmark/har_parser.py
@@ -1,10 +1,11 @@
 import json
-from urllib.parse import unquote_plus
-from pathlib import Path
 from operator import itemgetter
+from pathlib import Path
+from urllib.parse import unquote_plus
 
 import dateutil.parser
 from haralyzer import HarParser
+
 
 def parse_har_file(har_file_path):
     """
@@ -42,8 +43,10 @@ def parse_har_file(har_file_path):
 
     return requests
 
+
 def decode_post_data(url_encoded_data):
     return {unquote_plus(k): unquote_plus(v) for k, v in url_encoded_data.items()}
+
 
 def generate_har_benchmark(filename):
     filepath = Path(filename)
@@ -53,6 +56,7 @@ def generate_har_benchmark(filename):
     print("Processing request data:")
     for r in requests:
         print(f"{r['method']}: {r['url']}")
+
 
 if __name__ == '__main__':
     generate_har_benchmark('requests.har')

--- a/runner_benchmark/har_replay_test.py
+++ b/runner_benchmark/har_replay_test.py
@@ -1,6 +1,14 @@
+import os
+
 from locust import HttpLocust
 
 from har_taskset import HarFileTaskSet
 
+
 class SurveyRunnerSimpleScenario(HttpLocust):
     task_set = HarFileTaskSet
+    host = os.getenv("HOST", "http://localhost:5000")
+
+
+if __name__ == "__main__":
+    SurveyRunnerSimpleScenario().run()

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -7,11 +7,34 @@ from sdc.crypto.key_store import KeyStore
 
 KEY_PURPOSE_AUTHENTICATION = 'authentication'
 
-
 EQ_USER_AUTHENTICATION_RRM_PRIVATE_KEY_KID = '709eb42cfee5570058ce0711f730bfbb7d4c8ade'
 SR_USER_AUTHENTICATION_PUBLIC_KEY_KID = 'e19091072f920cbf3ca9f436ceba309e7d814a62'
 
 KEYS_FOLDER = './jwt-test-keys'
+
+PAYLOAD = {
+    'user_id': 'benchmark-user',
+    'period_str': 'July 2019',
+    'period_id': '201907',
+    'collection_exercise_sid': str(uuid4()),
+    'case_id': str(uuid4()),
+    'case_type': 'HI',
+    'display_address': '68 Abingdon Road, Goathill',
+    'ru_ref': '123456789012A',
+    'response_id': '1234567890123456',
+    'questionnaire_id': '0123456789000000',
+    'ru_name': 'Integration Testing',
+    'ref_p_start_date': '2019-04-01',
+    'ref_p_end_date': '2019-011-30',
+    'return_by': '2019-12-06',
+    'trad_as': 'Benchmark Tests',
+    'employment_date': '1983-06-02',
+    'region_code': 'GB-ENG',
+    'language_code': 'en',
+    'roles': [],
+    'account_service_url': 'http://upstream.url',
+    'variant_flags': {'sexual_identity': 'false'},
+}
 
 
 def get_file_contents(filename, trim=False):
@@ -36,36 +59,16 @@ _key_store = KeyStore({
 })
 
 
-def _get_payload_with_params(form_type_id, eq_id, survey_url=None, **extra_payload):
-    payload_vars = {
-        'user_id': 'integration-test',
-        'period_str': 'April 2016',
-        'period_id': '201604',
-        'collection_exercise_sid': str(uuid4()),
-        'ru_ref': '123456789012A',
-        'response_id': str(uuid4()),
-        'case_id': str(uuid4()),
-        'ru_name': 'Integration Testing',
-        'ref_p_start_date': '2016-04-01',
-        'ref_p_end_date': '2016-04-30',
-        'return_by': '2016-05-06',
-        'trad_as': 'Integration Tests',
-        'employment_date': '1983-06-02',
-        'variant_flags': None,
-        'region_code': 'GB-ENG',
-        'language_code': 'en',
-        'sexual_identity': False,
-        'roles': [],
-        'tx_id': str(uuid4()),
-        'eq_id': eq_id,
-        'form_type': form_type_id,
-        'iat': time.time(),
-        'exp': time.time() + float(3600),  # one hour from now
-        'jti': str(uuid4())
-    }
-
+def _get_payload_with_params(schema_name, survey_url=None, **extra_payload):
+    payload_vars = PAYLOAD.copy()
+    payload_vars['tx_id'] = str(uuid4())
+    payload_vars['schema_name'] = schema_name
     if survey_url:
         payload_vars['survey_url'] = survey_url
+
+    payload_vars['iat'] = time.time()
+    payload_vars['exp'] = payload_vars['iat'] + float(3600)  # one hour from now
+    payload_vars['jti'] = str(uuid4())
 
     for key, value in extra_payload.items():
         payload_vars[key] = value
@@ -73,8 +76,8 @@ def _get_payload_with_params(form_type_id, eq_id, survey_url=None, **extra_paylo
     return payload_vars
 
 
-def create_token(form_type_id, eq_id, **extra_payload):
-    payload_vars = _get_payload_with_params(form_type_id, eq_id, None, **extra_payload)
+def create_token(schema_name, **extra_payload):
+    payload_vars = _get_payload_with_params(schema_name, **extra_payload)
 
     return generate_token(payload_vars)
 

--- a/runner_benchmark/utils.py
+++ b/runner_benchmark/utils.py
@@ -3,24 +3,24 @@ import re
 
 class QuestionnaireMixins:
     client = None
-    csrftoken = None
-    prevurl = None
+    csrf_token = None
+    previous_url = None
 
     def get(self, *args, **kwargs):
         allow_redirects = kwargs.pop('allow_redirects', False)
         kwargs.pop('method', None)
 
-        print('GET', kwargs['url'])
+        print('\nGET', kwargs['url'])
 
         response = self.client.get(allow_redirects=allow_redirects, *args, **kwargs)
 
         if not response.content:
             raise Exception(f"No content in GET response for url: {kwargs['url']}")
 
-        self.csrftoken = _extract_csrf_token(response.content.decode('utf8'))
-        self.prevurl = kwargs['url']
+        self.csrf_token = _extract_csrf_token(response.content.decode('utf8'))
+        self.previous_url = kwargs['url']
 
-        print('csrftoken', self.csrftoken)
+        print('csrf_token', self.csrf_token)
 
         return response
 
@@ -29,10 +29,10 @@ class QuestionnaireMixins:
         kwargs.pop('method', None)
         allow_redirects = kwargs.pop('allow_redirects', False)
 
-        data['csrf_token'] = self.csrftoken
+        data['csrf_token'] = self.csrf_token
 
         headers = {
-            'Referer': self.prevurl
+            'Referer': self.previous_url
         }
 
         print('POST Headers', headers)


### PR DESCRIPTION
Benchmark now uses the newly introduced `schema_name` instead of `eq_id` and `form_type`.

### How to review
Ensure:
1. You can run benchmark tests following the README.