### PR TITLE
Use url names to group results by endpoint

### DIFF
--- a/runner_benchmark/questionnaire_mixins.py
+++ b/runner_benchmark/questionnaire_mixins.py
@@ -5,8 +5,8 @@ class QuestionnaireMixins:
     client = None
     csrf_token = None
 
-    def get(self, url, allow_redirects=False):
-        response = self.client.get(allow_redirects=allow_redirects, url=url)
+    def get(self, url, allow_redirects=False, name=None):
+        response = self.client.get(allow_redirects=allow_redirects, url=url, name=name)
 
         if not response.content:
             raise Exception(f"No content in GET response for url: {url}")
@@ -16,14 +16,14 @@ class QuestionnaireMixins:
 
         return response
 
-    def post(self, base_url, request_url, data={}):
+    def post(self, base_url, request_url, data={}, name=None):
 
         data['csrf_token'] = self.csrf_token
 
         headers = {'Referer': base_url}
 
         response = self.client.post(
-            allow_redirects=False, headers=headers, data=data, url=request_url
+            allow_redirects=False, headers=headers, data=data, url=request_url, name=name
         )
         return response
 


### PR DESCRIPTION
Removes the dynamic parts of urls so that the output is grouped properly.
- The token parameter is removed from `/session`
```
/session?token=eyJhbGciOiJSU0EtT0FFUCIsImVuYyI6IkEyNTZHQ00iLCJraWQiOiJlMTkwOTEwNzJmOTIwY2JmM2NhOWY0MzZjZWJhMzA5ZTdkODE0YTYyIn0.OpEtlvykXDp55ghZhmlAID77iVMr1PhFV...
 
/session
```

- List identifiers are replaced with {id}
```
/questionnaire/household/QRmCLe/add-or-edit-primary-person/

/questionnaire/household/{id}/add-or-edit-primary-person/
```

```
/questionnaire/relationships/WxnaNf/to/NIAwpJ

/questionnaire/relationships/{id}/to/{id}
```