### PR TITLE
Re-create benchmark against latest schema changes

### DIFF
--- a/requests/census_household_gb_eng.json
+++ b/requests/census_household_gb_eng.json
@@ -1,19 +1,9 @@
 {
     "requests": [
         {
-            "method": "GET",
-            "url": "/questionnaire/"
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/who-lives-here-interstitial/"
-        },
-        {
             "method": "POST",
             "url": "/questionnaire/who-lives-here-interstitial/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -23,8 +13,7 @@
             "method": "POST",
             "url": "/questionnaire/primary-person-list-collector/",
             "data": {
-                "you-live-here-answer": "Yes, I usually live here",
-                "action[save_continue]": ""
+                "you-live-here-answer": "Yes, I usually live here"
             },
             "redirect_route": "/questionnaire/household/{person_1_list_id}/add-or-edit-primary-person/"
         },
@@ -38,20 +27,18 @@
             "data": {
                 "first-name": "Joe",
                 "middle-names": "",
-                "last-name": "Bloggs",
-                "action[save_continue]": ""
+                "last-name": "Bloggs"
             }
         },
         {
             "method": "GET",
-            "url": "/questionnaire/anyone-else-list-collector/"
+            "url": "/questionnaire/anyone-else-list-collector/?list_item_id={person_1_list_id}"
         },
         {
             "method": "POST",
-            "url": "/questionnaire/anyone-else-list-collector/",
+            "url": "/questionnaire/anyone-else-list-collector/?list_item_id={person_1_list_id}",
             "data": {
-                "anyone-else-answer": "Yes, I need to add someone",
-                "action[save_continue]": ""
+                "anyone-else-answer": "Yes, I need to add someone"
             }
         },
         {
@@ -64,8 +51,7 @@
             "data": {
                 "first-name": "Silvia",
                 "middle-names": "",
-                "last-name": "Bloggs",
-                "action[save_continue]": ""
+                "last-name": "Bloggs"
             }
         },
         {
@@ -76,8 +62,7 @@
             "method": "POST",
             "url": "/questionnaire/anyone-else-list-collector/",
             "data": {
-                "anyone-else-answer": "No, I do not need to add anyone",
-                "action[save_continue]": ""
+                "anyone-else-answer": "No, I do not need to add anyone"
             }
         },
         {
@@ -88,8 +73,7 @@
             "method": "POST",
             "url": "/questionnaire/anyone-else-temp-away-list-collector/",
             "data": {
-                "anyone-else-temp-away-answer": "No, I do not need to add anyone",
-                "action[save_continue]": ""
+                "anyone-else-temp-away-answer": "No, I do not need to add anyone"
             }
         },
         {
@@ -100,8 +84,7 @@
             "method": "POST",
             "url": "/questionnaire/any-visitors/",
             "data": {
-                "any-visitors-answer": "People who usually live somewhere else in the UK, for example boy/girlfriends, friends or relatives",
-                "action[save_continue]": ""
+                "any-visitors-answer": "People who usually live somewhere else in the UK, for example boy/girlfriends, friends or relatives"
             }
         },
         {
@@ -113,8 +96,7 @@
             "url": "/questionnaire/visitor/add-visitor/?previous=any-visitors",
             "data": {
                 "first-name": "Sarah",
-                "last-name": "Bloggs",
-                "action[save_continue]": ""
+                "last-name": "Bloggs"
             }
         },
         {
@@ -125,8 +107,7 @@
             "method": "POST",
             "url": "/questionnaire/visitor-list-collector/",
             "data": {
-                "visitor-answer": "No, I do not need to add anyone",
-                "action[save_continue]": ""
+                "visitor-answer": "No, I do not need to add anyone"
             }
         },
         {
@@ -145,9 +126,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/relationships-interstitial/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -162,8 +141,7 @@
             "method": "POST",
             "url": "/questionnaire/relationships/{person_1_list_id}/to/{person_2_list_id}/",
             "data": {
-                "relationship-answer": "Husband or wife",
-                "action[save_continue]": ""
+                "relationship-answer": "Husband or wife"
             }
         },
         {
@@ -181,9 +159,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/accommodation-introduction/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -193,8 +169,7 @@
             "method": "POST",
             "url": "/questionnaire/accommodation-type/",
             "data": {
-                "accommodation-type-answer": "Whole house or bungalow",
-                "action[save_continue]": ""
+                "accommodation-type-answer": "Whole house or bungalow"
             }
         },
         {
@@ -205,8 +180,7 @@
             "method": "POST",
             "url": "/questionnaire/type-of-house/",
             "data": {
-                "type-of-house-answer": "Detached",
-                "action[save_continue]": ""
+                "type-of-house-answer": "Detached"
             }
         },
         {
@@ -217,8 +191,7 @@
             "method": "POST",
             "url": "/questionnaire/self-contained/",
             "data": {
-                "self-contained-answer": "Yes",
-                "action[save_continue]": ""
+                "self-contained-answer": "Yes"
             }
         },
         {
@@ -229,8 +202,7 @@
             "method": "POST",
             "url": "/questionnaire/number-of-bedrooms/",
             "data": {
-                "number-of-bedrooms-answer": "3",
-                "action[save_continue]": ""
+                "number-of-bedrooms-answer": "3"
             }
         },
         {
@@ -241,8 +213,7 @@
             "method": "POST",
             "url": "/questionnaire/central-heating/",
             "data": {
-                "central-heating-answer": "Mains gas",
-                "action[save_continue]": ""
+                "central-heating-answer": "Mains gas"
             }
         },
         {
@@ -253,8 +224,7 @@
             "method": "POST",
             "url": "/questionnaire/own-or-rent/",
             "data": {
-                "own-or-rent-answer": "Owns outright",
-                "action[save_continue]": ""
+                "own-or-rent-answer": "Owns outright"
             }
         },
         {
@@ -266,8 +236,7 @@
             "url": "/questionnaire/number-of-vehicles/",
             "data": {
                 "number-of-vehicles-answer": "1",
-                "number-of-vehicles-answer-other": "",
-                "action[save_continue]": ""
+                "number-of-vehicles-answer-other": ""
             }
         },
         {
@@ -294,9 +263,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/individual-interstitial/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -306,8 +273,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/proxy/",
             "data": {
-                "proxy-answer": "Yes, I am",
-                "action[save_continue]": ""
+                "proxy-answer": "Yes, I am"
             }
         },
         {
@@ -320,8 +286,7 @@
             "data": {
                 "date-of-birth-answer-day": "1",
                 "date-of-birth-answer-month": "1",
-                "date-of-birth-answer-year": "1965",
-                "action[save_continue]": ""
+                "date-of-birth-answer-year": "1965"
             }
         },
         {
@@ -332,8 +297,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/confirm-dob/",
             "data": {
-                "confirm-date-of-birth-answer": "Yes, I am {age_in_years} years old",
-                "action[save_continue]": ""
+                "confirm-date-of-birth-answer": "Yes, I am {age_in_years} years old"
             }
         },
         {
@@ -344,8 +308,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/sex/",
             "data": {
-                "sex-answer": "Male",
-                "action[save_continue]": ""
+                "sex-answer": "Male"
             }
         },
         {
@@ -356,8 +319,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/marriage-type/",
             "data": {
-                "marriage-type-answer": "Married",
-                "action[save_continue]": ""
+                "marriage-type-answer": "Married"
             }
         },
         {
@@ -368,8 +330,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/current-marriage-status/",
             "data": {
-                "current-marriage-status-answer": "Someone of the opposite sex",
-                "action[save_continue]": ""
+                "current-marriage-status-answer": "Someone of the opposite sex"
             }
         },
         {
@@ -381,8 +342,7 @@
             "url": "/questionnaire/household/{person_1_list_id}/another-address/",
             "data": {
                 "another-address-answer": "No",
-                "another-address-answer-other-country": "",
-                "action[save_continue]": ""
+                "another-address-answer-other-country": ""
             }
         },
         {
@@ -393,8 +353,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/in-education/",
             "data": {
-                "in-education-answer": "No",
-                "action[save_continue]": ""
+                "in-education-answer": "No"
             }
         },
         {
@@ -406,72 +365,7 @@
             "url": "/questionnaire/household/{person_1_list_id}/country-of-birth/",
             "data": {
                 "country-of-birth-answer": "England",
-                "country-of-birth-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/household/{person_1_list_id}/language/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/household/{person_1_list_id}/language/",
-            "data": {
-                "language-answer": "English",
-                "language-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/household/{person_1_list_id}/national-identity/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/household/{person_1_list_id}/national-identity/",
-            "data": {
-                "national-identity-answer": "English",
-                "national-identity-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/household/{person_1_list_id}/ethnic-group/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/household/{person_1_list_id}/ethnic-group/",
-            "data": {
-                "ethnic-group-answer": "White",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/household/{person_1_list_id}/white-ethnic-group/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/household/{person_1_list_id}/white-ethnic-group/",
-            "data": {
-                "white-ethnic-group-answer": "English, Welsh, Scottish, Northern Irish or British",
-                "white-ethnic-group-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/household/{person_1_list_id}/religion/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/household/{person_1_list_id}/religion/",
-            "data": {
-                "religion-answer": "No religion",
-                "religion-answer-other": "",
-                "action[save_continue]": ""
+                "country-of-birth-answer-other": ""
             }
         },
         {
@@ -483,8 +377,66 @@
             "url": "/questionnaire/household/{person_1_list_id}/past-usual-household-address/",
             "data": {
                 "past-usual-address-household-answer": "{household_address}",
-                "past-usual-address-household-answer-other": "",
-                "action[save_continue]": ""
+                "past-usual-address-household-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_1_list_id}/national-identity/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/household/{person_1_list_id}/national-identity/",
+            "data": {
+                "national-identity-answer": "English",
+                "national-identity-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_1_list_id}/ethnic-group/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/household/{person_1_list_id}/ethnic-group/",
+            "data": {
+                "ethnic-group-answer": "White"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_1_list_id}/white-ethnic-group/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/household/{person_1_list_id}/white-ethnic-group/",
+            "data": {
+                "white-ethnic-group-answer": "English, Welsh, Scottish, Northern Irish or British",
+                "white-ethnic-group-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_1_list_id}/religion/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/household/{person_1_list_id}/religion/",
+            "data": {
+                "religion-answer": "No religion",
+                "religion-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_1_list_id}/language/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/household/{person_1_list_id}/language/",
+            "data": {
+                "language-answer": "English",
+                "language-answer-other": ""
             }
         },
         {
@@ -496,8 +448,7 @@
             "url": "/questionnaire/household/{person_1_list_id}/passports/",
             "data": {
                 "passports-answer": "United Kingdom",
-                "passport-answer-other": "",
-                "action[save_continue]": ""
+                "passport-answer-other": ""
             }
         },
         {
@@ -508,8 +459,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/health/",
             "data": {
-                "health-answer": "Very good",
-                "action[save_continue]": ""
+                "health-answer": "Very good"
             }
         },
         {
@@ -520,8 +470,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/disability/",
             "data": {
-                "disability-answer": "No",
-                "action[save_continue]": ""
+                "disability-answer": "No"
             }
         },
         {
@@ -532,8 +481,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/carer/",
             "data": {
-                "carer-answer": "No",
-                "action[save_continue]": ""
+                "carer-answer": "No"
             }
         },
         {
@@ -545,8 +493,7 @@
             "url": "/questionnaire/household/{person_1_list_id}/sexual-identity/",
             "data": {
                 "sexual-identity-answer": "Straight or Heterosexual",
-                "sexual-identity-answer-other": "",
-                "action[save_continue]": ""
+                "sexual-identity-answer-other": ""
             }
         },
         {
@@ -558,8 +505,7 @@
             "url": "/questionnaire/household/{person_1_list_id}/birth-gender/",
             "data": {
                 "birth-gender-answer": "Yes",
-                "birth-gender-answer-other": "",
-                "action[save_continue]": ""
+                "birth-gender-answer-other": ""
             }
         },
         {
@@ -569,9 +515,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/qualifications/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -581,8 +525,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/apprenticeship/",
             "data": {
-                "apprenticeship-answer": "Yes",
-                "action[save_continue]": ""
+                "apprenticeship-answer": "Yes"
             }
         },
         {
@@ -593,8 +536,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/degree/",
             "data": {
-                "degree-answer": "Yes",
-                "action[save_continue]": ""
+                "degree-answer": "Yes"
             }
         },
         {
@@ -605,8 +547,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/nvq-level/",
             "data": {
-                "nvq-level-answer-exclusive": "None of these apply",
-                "action[save_continue]": ""
+                "nvq-level-answer-exclusive": "None of these apply"
             }
         },
         {
@@ -617,8 +558,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/a-level/",
             "data": {
-                "a-level-answer-exclusive": "None of these apply",
-                "action[save_continue]": ""
+                "a-level-answer-exclusive": "None of these apply"
             }
         },
         {
@@ -629,8 +569,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/gcse/",
             "data": {
-                "gcse-answer": "5 or more GCSEs grades A* to C or 9 to 4",
-                "action[save_continue]": ""
+                "gcse-answer": "5 or more GCSEs grades A* to C or 9 to 4"
             }
         },
         {
@@ -641,8 +580,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/armed-forces/",
             "data": {
-                "armed-forces-answer": "No",
-                "action[save_continue]": ""
+                "armed-forces-answer-exclusive": "No"
             }
         },
         {
@@ -653,8 +591,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/employment-status/",
             "data": {
-                "employment-status-answer": "Working as an employee",
-                "action[save_continue]": ""
+                "employment-status-answer": "Working as an employee"
             }
         },
         {
@@ -664,9 +601,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/main-employment-block/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -676,8 +611,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/main-job-type/",
             "data": {
-                "main-job-type-answer": "Self-employed or freelance without employees",
-                "action[save_continue]": ""
+                "main-job-type-answer": "Self-employed or freelance without employees"
             }
         },
         {
@@ -689,8 +623,7 @@
             "url": "/questionnaire/household/{person_1_list_id}/business-name/",
             "data": {
                 "business-name-answer": "",
-                "no-business-name-answer": "No organisation or work for a private individual",
-                "action[save_continue]": ""
+                "no-business-name-answer": "No organisation or work for a private individual"
             }
         },
         {
@@ -701,8 +634,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/job-title/",
             "data": {
-                "job-title-answer": "",
-                "action[save_continue]": ""
+                "job-title-answer": ""
             }
         },
         {
@@ -713,8 +645,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/job-description/",
             "data": {
-                "job-description-answer": "",
-                "action[save_continue]": ""
+                "job-description-answer": ""
             }
         },
         {
@@ -725,8 +656,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/employers-business/",
             "data": {
-                "employers-business-answer": "",
-                "action[save_continue]": ""
+                "employers-business-answer": ""
             }
         },
         {
@@ -736,9 +666,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/supervise/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -748,8 +676,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/hours-worked/",
             "data": {
-                "hours-worked-answer": "0 to 15 hours",
-                "action[save_continue]": ""
+                "hours-worked-answer": "0 to 15 hours"
             }
         },
         {
@@ -760,8 +687,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/work-travel/",
             "data": {
-                "work-travel-answer": "Work mainly at or from home",
-                "action[save_continue]": ""
+                "work-travel-answer": "Work mainly at or from home"
             }
         },
         {
@@ -772,8 +698,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/employer-type-of-address/",
             "data": {
-                "employer-type-of-address-answer": "At or from home",
-                "action[save_continue]": ""
+                "employer-type-of-address-answer": "At or from home"
             }
         },
         {
@@ -800,9 +725,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/individual-interstitial/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -811,9 +734,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/proxy/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -825,8 +746,7 @@
             "data": {
                 "date-of-birth-answer-day": "2",
                 "date-of-birth-answer-month": "2",
-                "date-of-birth-answer-year": "1965",
-                "action[save_continue]": ""
+                "date-of-birth-answer-year": "1965"
             }
         },
         {
@@ -837,8 +757,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/confirm-dob/",
             "data": {
-                "confirm-date-of-birth-answer": "Yes, {person_name} is {age_in_years} years old",
-                "action[save_continue]": ""
+                "confirm-date-of-birth-answer": "Yes, {person_name} is {age_in_years} years old"
             }
         },
         {
@@ -848,9 +767,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/sex/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -859,9 +776,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/marriage-type/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -871,8 +786,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/another-address/",
             "data": {
-                "another-address-answer-other-country": "",
-                "action[save_continue]": ""
+                "another-address-answer-other-country": ""
             }
         },
         {
@@ -883,8 +797,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/in-education/",
             "data": {
-                "in-education-answer": "No",
-                "action[save_continue]": ""
+                "in-education-answer": "No"
             }
         },
         {
@@ -896,71 +809,7 @@
             "url": "/questionnaire/household/{person_2_list_id}/country-of-birth/",
             "data": {
                 "country-of-birth-answer": "England",
-                "country-of-birth-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/household/{person_2_list_id}/language/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/household/{person_2_list_id}/language/",
-            "data": {
-                "language-answer": "English",
-                "language-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/household/{person_2_list_id}/national-identity/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/household/{person_2_list_id}/national-identity/",
-            "data": {
-                "national-identity-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/household/{person_2_list_id}/ethnic-group/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/household/{person_2_list_id}/ethnic-group/",
-            "data": {
-                "ethnic-group-answer": "White",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/household/{person_2_list_id}/white-ethnic-group/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/household/{person_2_list_id}/white-ethnic-group/",
-            "data": {
-                "white-ethnic-group-answer": "English, Welsh, Scottish, Northern Irish or British",
-                "white-ethnic-group-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/household/{person_2_list_id}/religion/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/household/{person_2_list_id}/religion/",
-            "data": {
-                "religion-answer": "No religion",
-                "religion-answer-other": "",
-                "action[save_continue]": ""
+                "country-of-birth-answer-other": ""
             }
         },
         {
@@ -972,8 +821,65 @@
             "url": "/questionnaire/household/{person_2_list_id}/past-usual-household-address/",
             "data": {
                 "past-usual-address-household-answer": "{household_address}",
-                "past-usual-address-household-answer-other": "",
-                "action[save_continue]": ""
+                "past-usual-address-household-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_2_list_id}/national-identity/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/household/{person_2_list_id}/national-identity/",
+            "data": {
+                "national-identity-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_2_list_id}/ethnic-group/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/household/{person_2_list_id}/ethnic-group/",
+            "data": {
+                "ethnic-group-answer": "White"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_2_list_id}/white-ethnic-group/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/household/{person_2_list_id}/white-ethnic-group/",
+            "data": {
+                "white-ethnic-group-answer": "English, Welsh, Scottish, Northern Irish or British",
+                "white-ethnic-group-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_2_list_id}/religion/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/household/{person_2_list_id}/religion/",
+            "data": {
+                "religion-answer": "No religion",
+                "religion-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_2_list_id}/language/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/household/{person_2_list_id}/language/",
+            "data": {
+                "language-answer": "English",
+                "language-answer-other": ""
             }
         },
         {
@@ -985,8 +891,7 @@
             "url": "/questionnaire/household/{person_2_list_id}/passports/",
             "data": {
                 "passports-answer": "United Kingdom",
-                "passport-answer-other": "",
-                "action[save_continue]": ""
+                "passport-answer-other": ""
             }
         },
         {
@@ -997,8 +902,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/health/",
             "data": {
-                "health-answer": "Very good",
-                "action[save_continue]": ""
+                "health-answer": "Very good"
             }
         },
         {
@@ -1008,9 +912,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/disability/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1019,9 +921,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/carer/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1031,8 +931,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/sexual-identity/",
             "data": {
-                "sexual-identity-answer-other": "",
-                "action[save_continue]": ""
+                "sexual-identity-answer-other": ""
             }
         },
         {
@@ -1043,8 +942,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/birth-gender/",
             "data": {
-                "birth-gender-answer-other": "",
-                "action[save_continue]": ""
+                "birth-gender-answer-other": ""
             }
         },
         {
@@ -1054,9 +952,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/qualifications/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1066,8 +962,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/apprenticeship/",
             "data": {
-                "apprenticeship-answer": "No",
-                "action[save_continue]": ""
+                "apprenticeship-answer": "No"
             }
         },
         {
@@ -1077,9 +972,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/degree/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1088,9 +981,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/nvq-level/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1099,9 +990,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/a-level/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1110,9 +999,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/gcse/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1121,9 +1008,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/other-qualifications/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1132,9 +1017,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/armed-forces/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1144,8 +1027,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/employment-status/",
             "data": {
-                "employment-status-answer": "Self-employed or freelance",
-                "action[save_continue]": ""
+                "employment-status-answer": "Self-employed or freelance"
             }
         },
         {
@@ -1155,9 +1037,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/main-employment-block/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1166,9 +1046,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/main-job-type/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1178,8 +1056,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/business-name/",
             "data": {
-                "business-name-answer": "",
-                "action[save_continue]": ""
+                "business-name-answer": ""
             }
         },
         {
@@ -1190,8 +1067,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/job-title/",
             "data": {
-                "job-title-answer": "",
-                "action[save_continue]": ""
+                "job-title-answer": ""
             }
         },
         {
@@ -1202,8 +1078,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/job-description/",
             "data": {
-                "job-description-answer": "",
-                "action[save_continue]": ""
+                "job-description-answer": ""
             }
         },
         {
@@ -1214,8 +1089,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/employers-business/",
             "data": {
-                "employers-business-answer": "",
-                "action[save_continue]": ""
+                "employers-business-answer": ""
             }
         },
         {
@@ -1225,9 +1099,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/supervise/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1236,9 +1108,15 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/hours-worked/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_2_list_id}/work-travel/"
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/household/{person_2_list_id}/hours-worked/"
         },
         {
             "method": "GET",
@@ -1247,9 +1125,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/work-travel/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1258,9 +1134,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/employer-type-of-address/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1274,8 +1148,7 @@
                 "employer-address-workplace-answer-street": "",
                 "employer-address-workplace-answer-city": "",
                 "employer-address-workplace-answer-county": "",
-                "employer-adress-workplace-answer-postcode": "",
-                "action[save_continue]": ""
+                "employer-address-workplace-answer-postcode": ""
             }
         },
         {
@@ -1299,14 +1172,16 @@
         },
         {
             "method": "GET",
+            "url": "/questionnaire/sections/visitor-section/{visitor_1_id}/"
+        },
+        {
+            "method": "GET",
             "url": "/questionnaire/visitor/{visitor_1_id}/visitor-interstitial/"
         },
         {
             "method": "POST",
             "url": "/questionnaire/visitor/{visitor_1_id}/visitor-interstitial/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1318,8 +1193,7 @@
             "data": {
                 "visitor-date-of-birth-answer-day": "",
                 "visitor-date-of-birth-answer-month": "",
-                "visitor-date-of-birth-answer-year": "",
-                "action[save_continue]": ""
+                "visitor-date-of-birth-answer-year": ""
             }
         },
         {
@@ -1329,9 +1203,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/visitor/{visitor_1_id}/visitor-sex/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -1341,8 +1213,7 @@
             "method": "POST",
             "url": "/questionnaire/visitor/{visitor_1_id}/usual-household-address/",
             "data": {
-                "usual-address-household-answer-other": "",
-                "action[save_continue]": ""
+                "usual-address-household-answer-other": ""
             }
         },
         {

--- a/requests/census_household_gb_eng.json
+++ b/requests/census_household_gb_eng.json
@@ -32,11 +32,11 @@
         },
         {
             "method": "GET",
-            "url": "/questionnaire/anyone-else-list-collector/?list_item_id={person_1_list_id}"
+            "url": "/questionnaire/anyone-else-list-collector/"
         },
         {
             "method": "POST",
-            "url": "/questionnaire/anyone-else-list-collector/?list_item_id={person_1_list_id}",
+            "url": "/questionnaire/anyone-else-list-collector/",
             "data": {
                 "anyone-else-answer": "Yes, I need to add someone"
             }

--- a/requests/census_individual_gb_eng.json
+++ b/requests/census_individual_gb_eng.json
@@ -4,8 +4,7 @@
             "method": "POST",
             "url": "/questionnaire/accommodation-type/",
             "data": {
-                "accommodation-type-answer": "A communal establishment",
-                "action[save_continue]": ""
+                "accommodation-type-answer": "A communal establishment"
             }
         },
         {
@@ -16,8 +15,7 @@
             "method": "POST",
             "url": "/questionnaire/proxy/",
             "data": {
-                "proxy-answer": "No, I\u2019m answering for myself",
-                "action[save_continue]": ""
+                "proxy-answer": "No, I\u2019m answering for myself"
             }
         },
         {
@@ -30,8 +28,7 @@
             "data": {
                 "first-name": "John",
                 "middle-names": "",
-                "last-name": "Smith",
-                "action[save_continue]": ""
+                "last-name": "Smith"
             }
         },
         {
@@ -42,8 +39,7 @@
             "method": "POST",
             "url": "/questionnaire/establishment-position/",
             "data": {
-                "establishment-position-answer": "Resident",
-                "action[save_continue]": ""
+                "establishment-position-answer": "Resident"
             }
         },
         {
@@ -56,8 +52,7 @@
             "data": {
                 "date-of-birth-answer-day": "01",
                 "date-of-birth-answer-month": "06",
-                "date-of-birth-answer-year": "1985",
-                "action[save_continue]": ""
+                "date-of-birth-answer-year": "1985"
             }
         },
         {
@@ -68,8 +63,7 @@
             "method": "POST",
             "url": "/questionnaire/confirm-dob/",
             "data": {
-                "confirm-date-of-birth-answer": "Yes, I am {age_in_years} years old",
-                "action[save_continue]": ""
+                "confirm-date-of-birth-answer": "Yes, I am {age_in_years} years old"
             }
         },
         {
@@ -80,8 +74,7 @@
             "method": "POST",
             "url": "/questionnaire/sex/",
             "data": {
-                "sex-answer": "Male",
-                "action[save_continue]": ""
+                "sex-answer": "Male"
             }
         },
         {
@@ -92,8 +85,7 @@
             "method": "POST",
             "url": "/questionnaire/marriage-type/",
             "data": {
-                "marriage-type-answer": "Married",
-                "action[save_continue]": ""
+                "marriage-type-answer": "Married"
             }
         },
         {
@@ -104,8 +96,7 @@
             "method": "POST",
             "url": "/questionnaire/current-marriage-status/",
             "data": {
-                "current-marriage-status-answer": "Someone of the opposite sex",
-                "action[save_continue]": ""
+                "current-marriage-status-answer": "Someone of the opposite sex"
             }
         },
         {
@@ -117,8 +108,7 @@
             "url": "/questionnaire/another-address/",
             "data": {
                 "another-address-answer": "No",
-                "another-address-answer-other-country": "",
-                "action[save_continue]": ""
+                "another-address-answer-other-country": ""
             }
         },
         {
@@ -129,8 +119,7 @@
             "method": "POST",
             "url": "/questionnaire/in-education/",
             "data": {
-                "in-education-answer": "No",
-                "action[save_continue]": ""
+                "in-education-answer": "No"
             }
         },
         {
@@ -142,72 +131,7 @@
             "url": "/questionnaire/country-of-birth/",
             "data": {
                 "country-of-birth-answer": "England",
-                "country-of-birth-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/language/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/language/",
-            "data": {
-                "language-answer": "English",
-                "language-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/national-identity/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/national-identity/",
-            "data": {
-                "national-identity-answer": "English",
-                "national-identity-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/ethnic-group/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/ethnic-group/",
-            "data": {
-                "ethnic-group-answer": "White",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/white-ethnic-group/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/white-ethnic-group/",
-            "data": {
-                "white-ethnic-group-answer": "English, Welsh, Scottish, Northern Irish or British",
-                "white-ethnic-group-answer-other": "",
-                "action[save_continue]": ""
-            }
-        },
-        {
-            "method": "GET",
-            "url": "/questionnaire/religion/"
-        },
-        {
-            "method": "POST",
-            "url": "/questionnaire/religion/",
-            "data": {
-                "religion-answer": "No religion",
-                "religion-answer-other": "",
-                "action[save_continue]": ""
+                "country-of-birth-answer-other": ""
             }
         },
         {
@@ -219,8 +143,66 @@
             "url": "/questionnaire/past-usual-household-address/",
             "data": {
                 "past-usual-address-household-answer": "{household_address}",
-                "past-usual-address-household-answer-other": "",
-                "action[save_continue]": ""
+                "past-usual-address-household-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/national-identity/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/national-identity/",
+            "data": {
+                "national-identity-answer": "English",
+                "national-identity-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/ethnic-group/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/ethnic-group/",
+            "data": {
+                "ethnic-group-answer": "White"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/white-ethnic-group/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/white-ethnic-group/",
+            "data": {
+                "white-ethnic-group-answer": "English, Welsh, Scottish, Northern Irish or British",
+                "white-ethnic-group-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/religion/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/religion/",
+            "data": {
+                "religion-answer": "No religion",
+                "religion-answer-other": ""
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/language/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/language/",
+            "data": {
+                "language-answer": "English",
+                "language-answer-other": ""
             }
         },
         {
@@ -232,8 +214,7 @@
             "url": "/questionnaire/passports/",
             "data": {
                 "passports-answer": "United Kingdom",
-                "passport-answer-other": "",
-                "action[save_continue]": ""
+                "passport-answer-other": ""
             }
         },
         {
@@ -244,8 +225,7 @@
             "method": "POST",
             "url": "/questionnaire/health/",
             "data": {
-                "health-answer": "Very good",
-                "action[save_continue]": ""
+                "health-answer": "Very good"
             }
         },
         {
@@ -256,8 +236,7 @@
             "method": "POST",
             "url": "/questionnaire/disability/",
             "data": {
-                "disability-answer": "No",
-                "action[save_continue]": ""
+                "disability-answer": "No"
             }
         },
         {
@@ -268,8 +247,7 @@
             "method": "POST",
             "url": "/questionnaire/carer/",
             "data": {
-                "carer-answer": "No",
-                "action[save_continue]": ""
+                "carer-answer": "No"
             }
         },
         {
@@ -281,8 +259,7 @@
             "url": "/questionnaire/sexual-identity/",
             "data": {
                 "sexual-identity-answer": "Straight or Heterosexual",
-                "sexual-identity-answer-other": "",
-                "action[save_continue]": ""
+                "sexual-identity-answer-other": ""
             }
         },
         {
@@ -294,8 +271,7 @@
             "url": "/questionnaire/birth-gender/",
             "data": {
                 "birth-gender-answer": "Yes",
-                "birth-gender-answer-other": "",
-                "action[save_continue]": ""
+                "birth-gender-answer-other": ""
             }
         },
         {
@@ -305,9 +281,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/qualifications/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -317,8 +291,7 @@
             "method": "POST",
             "url": "/questionnaire/apprenticeship/",
             "data": {
-                "apprenticeship-answer": "No",
-                "action[save_continue]": ""
+                "apprenticeship-answer": "No"
             }
         },
         {
@@ -329,8 +302,7 @@
             "method": "POST",
             "url": "/questionnaire/degree/",
             "data": {
-                "degree-answer": "Yes",
-                "action[save_continue]": ""
+                "degree-answer": "Yes"
             }
         },
         {
@@ -341,8 +313,7 @@
             "method": "POST",
             "url": "/questionnaire/nvq-level/",
             "data": {
-                "nvq-level-answer-exclusive": "None of these apply",
-                "action[save_continue]": ""
+                "nvq-level-answer-exclusive": "None of these apply"
             }
         },
         {
@@ -353,8 +324,7 @@
             "method": "POST",
             "url": "/questionnaire/a-level/",
             "data": {
-                "a-level-answer": "2 or more A levels",
-                "action[save_continue]": ""
+                "a-level-answer": "2 or more A levels"
             }
         },
         {
@@ -365,8 +335,7 @@
             "method": "POST",
             "url": "/questionnaire/gcse/",
             "data": {
-                "gcse-answer": "5 or more GCSEs grades A* to C or 9 to 4",
-                "action[save_continue]": ""
+                "gcse-answer": "5 or more GCSEs grades A* to C or 9 to 4"
             }
         },
         {
@@ -377,8 +346,7 @@
             "method": "POST",
             "url": "/questionnaire/armed-forces/",
             "data": {
-                "armed-forces-answer": "No",
-                "action[save_continue]": ""
+                "armed-forces-answer-exclusive": "No"
             }
         },
         {
@@ -389,8 +357,7 @@
             "method": "POST",
             "url": "/questionnaire/employment-status/",
             "data": {
-                "employment-status-answer": "Working as an employee",
-                "action[save_continue]": ""
+                "employment-status-answer": "Working as an employee"
             }
         },
         {
@@ -400,9 +367,7 @@
         {
             "method": "POST",
             "url": "/questionnaire/main-employment-block/",
-            "data": {
-                "action[save_continue]": ""
-            }
+            "data": {}
         },
         {
             "method": "GET",
@@ -412,8 +377,7 @@
             "method": "POST",
             "url": "/questionnaire/main-job-type/",
             "data": {
-                "main-job-type-answer": "Employee",
-                "action[save_continue]": ""
+                "main-job-type-answer": "Employee"
             }
         },
         {
@@ -424,8 +388,7 @@
             "method": "POST",
             "url": "/questionnaire/business-name/",
             "data": {
-                "business-name-answer": "Office for National Statistics",
-                "action[save_continue]": ""
+                "business-name-answer": "Office for National Statistics"
             }
         },
         {
@@ -436,8 +399,7 @@
             "method": "POST",
             "url": "/questionnaire/job-title/",
             "data": {
-                "job-title-answer": "Statistician",
-                "action[save_continue]": ""
+                "job-title-answer": "Statistician"
             }
         },
         {
@@ -448,8 +410,7 @@
             "method": "POST",
             "url": "/questionnaire/job-description/",
             "data": {
-                "job-description-answer": "RSI calculation",
-                "action[save_continue]": ""
+                "job-description-answer": "RSI calculation"
             }
         },
         {
@@ -460,8 +421,7 @@
             "method": "POST",
             "url": "/questionnaire/employers-business/",
             "data": {
-                "employers-business-answer": "Civil Service",
-                "action[save_continue]": ""
+                "employers-business-answer": "Civil Service"
             }
         },
         {
@@ -472,8 +432,7 @@
             "method": "POST",
             "url": "/questionnaire/supervise/",
             "data": {
-                "supervise-answer": "Yes",
-                "action[save_continue]": ""
+                "supervise-answer": "Yes"
             }
         },
         {
@@ -484,8 +443,7 @@
             "method": "POST",
             "url": "/questionnaire/hours-worked/",
             "data": {
-                "hours-worked-answer": "31 to 48 hours",
-                "action[save_continue]": ""
+                "hours-worked-answer": "31 to 48 hours"
             }
         },
         {
@@ -496,8 +454,7 @@
             "method": "POST",
             "url": "/questionnaire/work-travel/",
             "data": {
-                "work-travel-answer": "Driving a car or van",
-                "action[save_continue]": ""
+                "work-travel-answer": "Driving a car or van"
             }
         },
         {
@@ -508,8 +465,18 @@
             "method": "POST",
             "url": "/questionnaire/employer-type-of-address/",
             "data": {
-                "employer-type-of-address-answer": "At a workplace",
-                "action[save_continue]": ""
+                "employer-type-of-address-answer": "At a workplace"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/mainly-work-in-uk/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/mainly-work-in-uk/",
+            "data": {
+                "mainly-work-in-uk-answer": "Yes"
             }
         },
         {
@@ -524,8 +491,7 @@
                 "employer-address-workplace-answer-street": "Cardiff Road",
                 "employer-address-workplace-answer-city": "Newport",
                 "employer-address-workplace-answer-county": "Gwent",
-                "employer-adress-workplace-answer-postcode": "NP10 8XG",
-                "action[save_continue]": ""
+                "employer-address-workplace-answer-postcode": "NP10 8XG"
             }
         },
         {


### PR DESCRIPTION
### What is the context of this PR?
This updates individual and household schemas used in benchmark daily performance testing. All the latest schema routings, questions order, extra questions and content changes have been applied to eq-questionnaire-schemas repository.

### How to review 
Check the code and make sure all routing works as before.