### PR TITLE
Better error handling for 200 and 302 responses

### DIFF
--- a/requests/census_household_gb_eng.json
+++ b/requests/census_household_gb_eng.json
@@ -1,6 +1,10 @@
 {
     "requests": [
         {
+            "method": "GET",
+            "url": "/questionnaire/who-lives-here-interstitial/"
+        },
+        {
             "method": "POST",
             "url": "/questionnaire/who-lives-here-interstitial/",
             "data": {}

--- a/requests/census_individual_gb_eng.json
+++ b/requests/census_individual_gb_eng.json
@@ -1,6 +1,10 @@
 {
     "requests": [
         {
+            "method": "GET",
+            "url": "/questionnaire/accommodation-type/"
+        },
+        {
             "method": "POST",
             "url": "/questionnaire/accommodation-type/",
             "data": {

--- a/requests/test_checkbox.json
+++ b/requests/test_checkbox.json
@@ -1,6 +1,10 @@
 {
     "requests": [
         {
+            "method": "GET",
+            "url": "/questionnaire/mandatory-checkbox/"
+        },
+        {
             "method": "POST",
             "url": "/questionnaire/mandatory-checkbox/",
             "data": {

--- a/runner_benchmark/questionnaire_mixins.py
+++ b/runner_benchmark/questionnaire_mixins.py
@@ -5,31 +5,48 @@ class QuestionnaireMixins:
     client = None
     csrf_token = None
 
-    def get(self, url, allow_redirects=False, name=None):
-        response = self.client.get(allow_redirects=allow_redirects, url=url, name=name)
+    def get(self, url, name=None, expect_redirect=False):
+        with self.client.get(url=url, name=name, allow_redirects=False, catch_response=True) as response:
+            
+            if expect_redirect:
+                if response.status_code != 302:
+                    error = f"Expected a (302) but got a ({response.status_code}) back when getting page: {url}"
+                    response.failure(error)
+                    raise Exception(error)
+                return response
 
-        if not response.content:
-            raise Exception(f"No content in GET response for url: {url}")
+            if response.status_code != 200:
+                error = f"Expected a (200) but got a ({response.status_code}) back when getting page: {url}"
+                response.failure(error)
+                raise Exception(error)
 
-        if response.status_code != 302:
+            if not response.content:
+                response.failure(f"No content in GET response for url: {url}")
+
             self.csrf_token = _extract_csrf_token(response.content.decode('utf8'))
 
-        return response
+            return response
 
     def post(self, base_url, request_url, data={}, name=None):
 
         data['csrf_token'] = self.csrf_token
-
         headers = {'Referer': base_url}
 
-        response = self.client.post(
+        with self.client.post(
             allow_redirects=False,
             headers=headers,
             data=data,
             url=request_url,
             name=name,
-        )
-        return response
+            catch_response=True,
+        ) as response:
+
+            if response.status_code != 302:
+                error = f"Expected a (302) but got a ({response.status_code}) back when posting page: {request_url} with data: {data}"
+                response.failure(error)
+                raise Exception(error)
+
+            return response
 
 
 CSRF_REGEX = re.compile(

--- a/runner_benchmark/taskset.py
+++ b/runner_benchmark/taskset.py
@@ -39,19 +39,18 @@ class SurveyRunnerTaskSet(TaskSet, QuestionnaireMixins):
         user_wait_time_max = int(os.getenv('USER_WAIT_TIME_MAX_SECONDS', 2))
         url_name_regex = r'{.*?}'
 
+        self.get('/questionnaire', expect_redirect=True )
+
         for request in self.requests:
             url_name = re.sub(url_name_regex, '{id}', request['url'])
             request_url = request['url'].format_map(self.redirect_params)
 
             if request['method'] == 'GET':
-                response = self.get(request_url, name=url_name)
+                expect_redirect = "redirect_route" in request
+                response = self.get(request_url, name=url_name, expect_redirect=expect_redirect)
 
-                if response.status_code not in [200, 302]:
-                    raise Exception(
-                        f"Got a ({response.status_code}) back when getting page: {request_url}"
-                    )
-
-                self.handle_redirect(request, response)
+                if expect_redirect:
+                    self.handle_redirect(request, response)
 
                 if user_wait_time_min and user_wait_time_max:
                     time.sleep(r.randrange(user_wait_time_min, user_wait_time_max))
@@ -60,13 +59,8 @@ class SurveyRunnerTaskSet(TaskSet, QuestionnaireMixins):
                 response = self.post(
                     self.base_url, request_url, request['data'], name=url_name
                 )
-
-                if response.status_code not in [200, 302]:
-                    raise Exception(
-                        f"Got a ({response.status_code}) back when posting page: {request_url} with data: {request['data']}"
-                    )
-
-                self.handle_redirect(request, response)
+                if "redirect_route" in request:
+                    self.handle_redirect(request, response)
 
             else:
                 raise Exception(
@@ -74,25 +68,14 @@ class SurveyRunnerTaskSet(TaskSet, QuestionnaireMixins):
                 )
 
     def handle_redirect(self, request, response):
-        if response.status_code == 302:
-            if 'redirect_route' in request:
-                self.redirect_params.update(
-                    parse_params_from_location(
-                        response.headers['Location'], request['redirect_route']
-                    )
-                )
+        self.redirect_params.update(
+            parse_params_from_location(
+                response.headers['Location'], request['redirect_route']
+            )
+        )
 
     def do_launch_survey(self):
         token = create_token(schema_name=self.schema_name)
 
         url = f'/session?token={token}'
-        response = self.get(url, name='/session')
-
-        if response.status_code != 302:
-            raise Exception(
-                'Got a non-302 back when authenticating session: {}'.format(
-                    response.status_code
-                )
-            )
-
-        self.get(response.headers['Location'], allow_redirects=True)
+        self.get(url=url, name='/session', expect_redirect=True)


### PR DESCRIPTION
# Context

Currently when something breaks in a request file it is hard to detect. This pull request enforces expected 200 responses for GET requests (a redirect would mean the requested page wasn't possible) and 302 for POST responses (a 200 response would probably mean a form validation failure). 

If an un-expected response is detected, the response is failed and an exception raised. Failing the response highlights the endpoint that caused the failure in the CSV file output. Raising the exception aborts the task, meaning no further requests for the task are executed after a failing one. It also gives clear failures when running from the command line.

# How to test

- Run the test requests files and verify the output
- Try an incorrect URL on a GET request and review the output
- Try an incorrect POST (e.g. invalid radio option) and review the output