### PR TITLE
Add CPU to job

### DIFF
--- a/k8s/helm/templates/locust-job.yaml
+++ b/k8s/helm/templates/locust-job.yaml
@@ -23,6 +23,9 @@ spec:
         - name: "{{ .Chart.Name }}"
           image: "{{ .Values.container.image }}"
           imagePullPolicy: "{{ .Values.container.pullPolicy }}"
+          resources:
+            requests:
+              cpu: 0.7
           env:
             - name: HOST
               value: "{{ .Values.host }}"


### PR DESCRIPTION
We expect to run one instance of the benchmark per node in order to guarantee the network capacity required. This pull request fixes the CPU request to 0.7 to force this to happen.