### PR TITLE
Use correct percentile in analysis

### DIFF
--- a/scripts/visualise_results.py
+++ b/scripts/visualise_results.py
@@ -15,7 +15,7 @@ def get_stats(folders):
         post_request_response_times = []
         all_response_times = []
 
-        for file in glob(folder + '/*distribution.csv') or glob(folder + '/*stats.csv'):
+        for file in glob(folder + '/*stats.csv'):
 
             with open(file) as f:
                 data = f.read()
@@ -29,19 +29,12 @@ def get_stats(folders):
 
                 values = line.split(',')
 
-                if 'distribution' in file:
-                    percentile_99th = int(values[9])
-                    if 'GET /questionnaire' in line:
+                percentile_99th = int(values[18])
+                if values[1].startswith('"/questionnaire'):
+                    if values[0] == '"GET"':
                         get_values.append(percentile_99th)
-                    elif 'POST /questionnaire' in line:
+                    elif values[0] == '"POST"':
                         post_values.append(percentile_99th)
-                else:
-                    percentile_99th = int(values[19])
-                    if values[1].startswith('"/questionnaire'):
-                        if values[0] == '"GET"':
-                            get_values.append(percentile_99th)
-                        elif values[0] == '"POST"':
-                            post_values.append(percentile_99th)
 
             get_request_response_times.extend(get_values)
             post_request_response_times.extend(post_values)


### PR DESCRIPTION
Previous to this change the incorrect column was being used so we were reporting on the 99.9th percentile timings rather than the 99th.

I have also removed the logic for `_distribution.csv` files as they no longer exist and their replacement (`_output_stats_history.csv`) uses a different format.

### How to test
- Follow the instructions in the Readme to run the visualise results script with the contents of the `eq-daily-performance-test-benchmark-outputs` bucket
- Verify the correct timings are graphed