### PR TITLE
Allow non-minified html pages in csrf regex

### DIFF
--- a/runner_benchmark/questionnaire_mixins.py
+++ b/runner_benchmark/questionnaire_mixins.py
@@ -52,7 +52,7 @@ class QuestionnaireMixins:
 
 
 CSRF_REGEX = re.compile(
-    r'<input id="csrf_token" name="csrf_token" type="hidden" value="(.+?)">'
+    r'<input id="csrf_token" name="csrf_token" type="hidden" value="(.+?)"\/?>'
 )
 
 


### PR DESCRIPTION
### What is the context of this PR?

Benchmark doesn't correctly identify non minified versions of pages, due to an extra forward slash at the end of the `<input />`. This change adds it to allow locust to match non-minified pages.

### How to review 

Run a journey locally against runner with the env var EQ_ENABLE_HTML_MINIFY set to True and then False and ensure both run through the journeys successfully. 
