### PR TITLE
Upgrade to Helm 3

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -40,13 +40,15 @@ RUNNER_FULLY_QUALIFIED_DOMAIN_NAME=<runner_fqdn> \
 DOCKER_REGISTRY=<docker_registry_for_app_images> \
 IMAGE_TAG=<image_tag> \
 USER_WAIT_TIME_MIN_SECONDS=<user_min_wait_time> \
-USER_WAIT_TIME_MAX_SECONDS=<user_max_wait_time< \
+USER_WAIT_TIME_MAX_SECONDS=<user_max_wait_time> \
 PARALLELISM=<number_of_jobs_to_run> \
 TIMEOUT=<job_timeout> \
 OUTPUT_DIR=<folder_where_outputs_are_stored> \
 OUTPUT_BUCKET=<bucket_where_outputs_are_stored> \
 fly -t census-eq execute \
-  --config ci/run_benchmark.yaml
+  --config ci/run_benchmark.yaml \
+  -v image_registry=<docker-registry> \
+  -v deploy_image_version=<image-tag>
 ```
 
 ## Output results to Slack

--- a/ci/run-benchmark.yaml
+++ b/ci/run-benchmark.yaml
@@ -2,7 +2,8 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: theorf/google-cloud-sdk-helm
+    repository: ((image_registry))/eq-app-deploy-image
+    tag: ((deploy_image_version))
 inputs:
   - name: eq-survey-runner-benchmark
 params:
@@ -25,8 +26,6 @@ run:
   args:
     - -exc
     - |
-      apt-get install -y procps
-
       cat >~/gcloud-service-key.json <<EOL
       $SERVICE_ACCOUNT_JSON
       EOL
@@ -35,15 +34,11 @@ run:
 
       cd eq-survey-runner-benchmark
 
-      helm init --client-only
-      helm plugin install https://github.com/rimusz/helm-tiller
-
       RUNTIME_DATE_STRING="$(date +'%Y-%m-%dT%H:%M:%S')"
 
       gcloud container clusters get-credentials runner-benchmark --region ${REGION} --project ${PROJECT_ID}
 
-      helm tiller run \
-        helm upgrade --install \
+      helm upgrade --install \
         runner-benchmark \
         k8s/helm \
         --set requestsJson="${REQUESTS_JSON}" \

--- a/k8s/helm/Chart.yaml
+++ b/k8s/helm/Chart.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
-description: A Helm chart for deploying Locust test runner for Survey Runner to Kubernetes
+description: A Helm chart for deploying Locust test runner for Questionnaire Runner to Kubernetes
 name: runner-benchmark
-version: 0.1.0
+version: 1.0.0


### PR DESCRIPTION
### What is the context of this PR?
Updates the run benchmark Concourse task to use the Helm3 build image.

### How to review 
Test either via the Concourse task or the associated [pipeline change](https://github.com/ONSdigital/eq-pipelines/pull/72).
