### PR TITLE
Add stress test summary script

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ To run the script and download results:
 OUTPUT_BUCKET="<bucket_name>" pipenv run python -m scripts.get_benchmark_results
 ```
 
-### Summarise the results
+### Summarise the Daily Benchmark results
 You can get a breakdown of the average response times for a result set by doing:
 ```bash
 OUTPUT_DIR="outputs/daily-test" \

--- a/README.md
+++ b/README.md
@@ -217,6 +217,23 @@ All requests average: 524ms
 
 If `OUTPUT_DATE` is not provided, then it will output a summary for all results within the provided directory.
 
+### Summmarise stress test results:
+To get a breakdown of results for a stress test use the `get_stress_test_summary` script. This accepts a folder containing
+results as a parameter, and will provide aggregate totals at the folder level:
+```bash
+OUTPUT_DIR="outputs/stress-test" pipenv run python -m scripts.get_stress_test_summary
+```
+
+This will output something like:
+```
+Questionnaire GETs average: 465ms
+Questionnaire POSTs average: 525ms
+All requests average: 495ms
+Total Requests: 30056523
+Total Failures: 140186
+Error Percentage: 0.47%
+```
+
 ### Run the Visualise Results script
 
 The `visualise_results` script will run against any benchmark results stored in the directory that is passed as an environment variable to the script.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ All requests average: 524ms
 
 If `OUTPUT_DATE` is not provided, then it will output a summary for all results within the provided directory.
 
-### Summmarise stress test results:
+### Summarise Stress Test results:
 To get a breakdown of results for a stress test use the `get_stress_test_summary` script. This accepts a folder containing
 results as a parameter, and will provide aggregate totals at the folder level:
 ```bash

--- a/README.md
+++ b/README.md
@@ -213,6 +213,9 @@ This will output something like:
 Questionnaire GETs average: 477ms
 Questionnaire POSTs average: 573ms
 All requests average: 524ms
+Total Requests: 209303
+Total Failures: 0
+Error Percentage: 0.0%
 ```
 
 If `OUTPUT_DATE` is not provided, then it will output a summary for all results within the provided directory.

--- a/scripts/get_stats.py
+++ b/scripts/get_stats.py
@@ -5,9 +5,9 @@ from glob import glob
 class BenchmarkStats:
     get: [int] = field(default_factory=list)
     post: [int] = field(default_factory=list)
-    average_get: int = None
-    average_post: int = None
-    average_total: int = None
+    average_get: int = 0
+    average_post: int = 0
+    average_total: int = 0
     total_requests: int = 0
     total_failures: int = 0
     error_percentage: int = 0

--- a/scripts/get_stats.py
+++ b/scripts/get_stats.py
@@ -1,0 +1,38 @@
+from glob import glob
+
+
+def get_stats(folder):
+    stats = {
+        "get": [],
+        "post": [],
+        "average_get": None,
+        "average_post": None,
+        "average_total": None,
+        "total_requests": 0,
+        "total_failures": 0,
+        "error_percentage": 0
+    }
+
+    for file in glob(folder + '/*stats.csv'):
+
+        with open(file) as f:
+            data = f.read()
+
+        for line in data.split('\n'):
+            if 'Name' in line:
+                continue
+
+            values = line.split(',')
+
+            percentile_99th = int(values[18])
+            if values[1].startswith('"/questionnaire'):
+                if values[0] == '"GET"':
+                    stats["get"].append(percentile_99th)
+                elif values[0] == '"POST"':
+                    stats["post"].append(percentile_99th)
+
+        if 'Aggregated' in line:
+            stats["total_requests"] = stats["total_requests"] + int(values[2])
+            stats["total_failures"] = stats["total_failures"] + int(values[3])
+
+    return stats

--- a/scripts/get_stats.py
+++ b/scripts/get_stats.py
@@ -12,6 +12,16 @@ class BenchmarkStats:
     total_failures: int = 0
     error_percentage: int = 0
 
+    def __str__(self):
+        return (
+            f'Questionnaire GETs average: {int(self.average_get)}ms\n'
+            f'Questionnaire POSTs average: {int(self.average_post)}ms\n'
+            f'All requests average: {int(self.average_total)}ms\n'
+            f'Total Requests: {int(self.total_requests)}\n'
+            f'Total Failures: {int(self.total_failures)}\n'
+            f'Error Percentage: {(round(self.error_percentage, 2))}%\n'
+        )
+
 
 def get_stats(folder):
     stats = BenchmarkStats()
@@ -34,8 +44,8 @@ def get_stats(folder):
                 elif values[0] == '"POST"':
                     stats.post.append(percentile_99th)
 
-        if "Aggregated" in line:
-            stats.total_requests = stats.total_requests + int(values[2])
-            stats.total_failures = stats.total_failures + int(values[3])
+            if "Aggregated" in line:
+                stats.total_requests = stats.total_requests + int(values[2])
+                stats.total_failures = stats.total_failures + int(values[3])
 
     return stats

--- a/scripts/get_stats.py
+++ b/scripts/get_stats.py
@@ -10,19 +10,19 @@ def get_stats(folder):
         "average_total": None,
         "total_requests": 0,
         "total_failures": 0,
-        "error_percentage": 0
+        "error_percentage": 0,
     }
 
-    for file in glob(folder + '/*stats.csv'):
+    for file in glob(folder + "/*stats.csv"):
 
         with open(file) as f:
             data = f.read()
 
-        for line in data.split('\n'):
-            if 'Name' in line:
+        for line in data.split("\n"):
+            if "Name" in line:
                 continue
 
-            values = line.split(',')
+            values = line.split(",")
 
             percentile_99th = int(values[18])
             if values[1].startswith('"/questionnaire'):
@@ -31,7 +31,7 @@ def get_stats(folder):
                 elif values[0] == '"POST"':
                     stats["post"].append(percentile_99th)
 
-        if 'Aggregated' in line:
+        if "Aggregated" in line:
             stats["total_requests"] = stats["total_requests"] + int(values[2])
             stats["total_failures"] = stats["total_failures"] + int(values[3])
 

--- a/scripts/get_stats.py
+++ b/scripts/get_stats.py
@@ -1,25 +1,16 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from glob import glob
 
 @dataclass
 class BenchmarkStats:
-    get: []
-    post: []
-    average_get: None
-    average_post: None
-    average_total: None
-    total_requests: int
-    total_failures: int
-    error_percentage: int
-
-    def __init__(self):
-        self.get = []
-        self.post = []
-        self.average_get = None
-        self.average_post = None
-        self.total_requests = 0
-        self.total_failures = 0
-        self.error_percentage = 0
+    get: [int] = field(default_factory=list)
+    post: [int] = field(default_factory=list)
+    average_get: int = None
+    average_post: int = None
+    average_total: int = None
+    total_requests: int = 0
+    total_failures: int = 0
+    error_percentage: int = 0
 
 
 def get_stats(folder):

--- a/scripts/get_stats.py
+++ b/scripts/get_stats.py
@@ -1,17 +1,29 @@
+from dataclasses import dataclass
 from glob import glob
+
+@dataclass
+class BenchmarkStats:
+    get: []
+    post: []
+    average_get: None
+    average_post: None
+    average_total: None
+    total_requests: int
+    total_failures: int
+    error_percentage: int
+
+    def __init__(self):
+        self.get = []
+        self.post = []
+        self.average_get = None
+        self.average_post = None
+        self.total_requests = 0
+        self.total_failures = 0
+        self.error_percentage = 0
 
 
 def get_stats(folder):
-    stats = {
-        "get": [],
-        "post": [],
-        "average_get": None,
-        "average_post": None,
-        "average_total": None,
-        "total_requests": 0,
-        "total_failures": 0,
-        "error_percentage": 0,
-    }
+    stats = BenchmarkStats()
 
     for file in glob(folder + "/*stats.csv"):
 
@@ -27,12 +39,12 @@ def get_stats(folder):
             percentile_99th = int(values[18])
             if values[1].startswith('"/questionnaire'):
                 if values[0] == '"GET"':
-                    stats["get"].append(percentile_99th)
+                    stats.get.append(percentile_99th)
                 elif values[0] == '"POST"':
-                    stats["post"].append(percentile_99th)
+                    stats.post.append(percentile_99th)
 
         if "Aggregated" in line:
-            stats["total_requests"] = stats["total_requests"] + int(values[2])
-            stats["total_failures"] = stats["total_failures"] + int(values[3])
+            stats.total_requests = stats.total_requests + int(values[2])
+            stats.total_failures = stats.total_failures + int(values[3])
 
     return stats

--- a/scripts/get_stress_test_summary.py
+++ b/scripts/get_stress_test_summary.py
@@ -1,34 +1,23 @@
 import os
 import statistics
 from glob import glob
-from scripts.get_stats import get_stats
+from scripts.get_stats import get_stats, BenchmarkStats
 
 
 def get_results(folders):
-    results = {
-        "get": [],
-        "post": [],
-        "average_get": [],
-        "average_post": [],
-        "average_total": [],
-        "error_percentage": 0,
-        "total_requests": 0,
-        "total_failures": 0,
-    }
+    results = BenchmarkStats()
 
     for folder in folders:
         stats = get_stats(folder)
-        results["get"].extend(stats["get"])
-        results["post"].extend(stats["post"])
-        results["total_requests"] = results["total_requests"] + stats["total_requests"]
-        results["total_failures"] = results["total_failures"] + stats["total_failures"]
+        results.get.extend(stats.get)
+        results.post.extend(stats.post)
+        results.total_requests = results.total_requests + stats.total_requests
+        results.total_failures = results.total_failures + stats.total_failures
 
-    results["average_get"] = statistics.mean(results["get"])
-    results["average_post"] = statistics.mean(results["post"])
-    results["average_total"] = statistics.mean(results["get"] + results["post"])
-    results["error_percentage"] = (results["total_failures"] * 100) / results[
-        "total_requests"
-    ]
+    results.average_get = statistics.mean(results.get)
+    results.average_post = statistics.mean(results.post)
+    results.average_total = statistics.mean(results.get + results.post)
+    results.error_percentage = (results.total_failures * 100) / results.total_requests
 
     return results
 
@@ -46,12 +35,12 @@ if __name__ == "__main__":
     result = get_results(sorted_folders)
 
     summary = (
-        f'Questionnaire GETs average: {int(result["average_get"])}ms\n'
-        f'Questionnaire POSTs average: {int(result["average_post"])}ms\n'
-        f'All requests average: {int(result["average_total"])}ms\n'
-        f'Total Requests: {int(result["total_requests"])}\n'
-        f'Total Failures: {int(result["total_failures"])}\n'
-        f'Error Percentage: {(round(result["error_percentage"], 2))}%\n'
+        f'Questionnaire GETs average: {int(result.average_get)}ms\n'
+        f'Questionnaire POSTs average: {int(result.average_post)}ms\n'
+        f'All requests average: {int(result.average_total)}ms\n'
+        f'Total Requests: {int(result.total_requests)}\n'
+        f'Total Failures: {int(result.total_failures)}\n'
+        f'Error Percentage: {(round(result.error_percentage, 2))}%\n'
     )
 
     print(summary)

--- a/scripts/get_stress_test_summary.py
+++ b/scripts/get_stress_test_summary.py
@@ -1,4 +1,4 @@
-import os
+import os, sys
 import statistics
 from glob import glob
 from scripts.get_stats import get_stats, BenchmarkStats
@@ -11,8 +11,8 @@ def get_results(folders):
         stats = get_stats(folder)
         results.get.extend(stats.get)
         results.post.extend(stats.post)
-        results.total_requests = results.total_requests + stats.total_requests
-        results.total_failures = results.total_failures + stats.total_failures
+        results.total_requests += stats.total_requests
+        results.total_failures += stats.total_failures
 
     results.average_get = statistics.mean(results.get)
     results.average_post = statistics.mean(results.post)
@@ -34,13 +34,4 @@ if __name__ == "__main__":
     sorted_folders = sorted(glob(f"{folder}/*"))
     result = get_results(sorted_folders)
 
-    summary = (
-        f'Questionnaire GETs average: {int(result.average_get)}ms\n'
-        f'Questionnaire POSTs average: {int(result.average_post)}ms\n'
-        f'All requests average: {int(result.average_total)}ms\n'
-        f'Total Requests: {int(result.total_requests)}\n'
-        f'Total Failures: {int(result.total_failures)}\n'
-        f'Error Percentage: {(round(result.error_percentage, 2))}%\n'
-    )
-
-    print(summary)
+    print(result)

--- a/scripts/get_stress_test_summary.py
+++ b/scripts/get_stress_test_summary.py
@@ -13,7 +13,7 @@ def get_results(folders):
         "average_total": [],
         "error_percentage": 0,
         "total_requests": 0,
-        "total_failures": 0
+        "total_failures": 0,
     }
 
     for folder in folders:
@@ -26,7 +26,9 @@ def get_results(folders):
     results["average_get"] = statistics.mean(results["get"])
     results["average_post"] = statistics.mean(results["post"])
     results["average_total"] = statistics.mean(results["get"] + results["post"])
-    results["error_percentage"] = (results["total_failures"] * 100) / results["total_requests"]
+    results["error_percentage"] = (results["total_failures"] * 100) / results[
+        "total_requests"
+    ]
 
     return results
 
@@ -35,15 +37,13 @@ def parse_environment_variables():
     try:
         output_dir = os.environ["OUTPUT_DIR"]
     except KeyError:
-        print(
-            "'OUTPUT_DIR' environment variable must be set e.g. outputs/daily-test"
-        )
+        print("'OUTPUT_DIR' environment variable must be set e.g. outputs/daily-test")
         sys.exit(1)
 
     return output_dir
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     folder = parse_environment_variables()
 
     sorted_folders = sorted(glob(f"{folder}/*"))

--- a/scripts/get_stress_test_summary.py
+++ b/scripts/get_stress_test_summary.py
@@ -1,0 +1,78 @@
+import os
+import statistics
+import sys
+from glob import glob
+
+
+def get_results(folders):
+
+    results = {
+        "get": [],
+        "post": [],
+        "average_get": None,
+        "average_post": None,
+        "average_total": None,
+        "total_requests": 0,
+        "total_failures": 0,
+        "error_percentage": 0
+    }
+
+    for folder in folders:
+        for file in glob(folder + '/*stats.csv'):
+
+            with open(file) as f:
+                data = f.read()
+
+            for line in data.split('\n'):
+                if 'Name' in line:
+                    continue
+
+                values = line.split(',')
+
+                percentile_99th = int(values[18])
+                if values[1].startswith('"/questionnaire'):
+                    if values[0] == '"GET"':
+                        results["get"].append(percentile_99th)
+                    elif values[0] == '"POST"':
+                        results["post"].append(percentile_99th)
+
+                if 'Aggregated' in line:
+                    results["total_requests"] = results["total_requests"] + int(values[2])
+                    results["total_failures"] = results["total_failures"] + int(values[3])
+
+        results["average_get"] = statistics.mean(results["get"])
+        results["average_post"] = statistics.mean(results["post"])
+        results["average_total"] = statistics.mean(results["get"] + results["post"])
+        results["error_percentage"] = (results["total_failures"] * 100) / results["total_requests"]
+
+    return results
+
+
+def parse_environment_variables():
+    output_dir = os.getenv("OUTPUT_DIR")
+
+    if not output_dir:
+        print(
+            "'OUTPUT_DIR' environment variable must be provided e.g. outputs/daily-test"
+        )
+        sys.exit(1)
+
+    return output_dir
+
+
+if __name__ == '__main__':
+    folder = parse_environment_variables()
+
+    sorted_folders = sorted(glob(f"{folder}/*"))
+    result = get_results(sorted_folders)
+
+    summary = (
+        f'Questionnaire GETs average: {int(result["average_get"])}ms\n'
+        f'Questionnaire POSTs average: {int(result["average_post"])}ms\n'
+        f'All requests average: {int(result["average_total"])}ms\n'
+        f'Total Requests: {int(result["total_requests"])}\n'
+        f'Total Failures: {int(result["total_failures"])}\n'
+        f'Error Percentage: {(round(result["error_percentage"], 2))}%\n'
+    )
+
+    print(summary)

--- a/scripts/get_stress_test_summary.py
+++ b/scripts/get_stress_test_summary.py
@@ -5,7 +5,6 @@ from scripts.get_stats import get_stats
 
 
 def get_results(folders):
-
     results = {
         "get": [],
         "post": [],
@@ -33,11 +32,11 @@ def get_results(folders):
 
 
 def parse_environment_variables():
-    output_dir = os.getenv("OUTPUT_DIR")
-
-    if not output_dir:
+    try:
+        output_dir = os.environ["OUTPUT_DIR"]
+    except KeyError:
         print(
-            "'OUTPUT_DIR' environment variable must be provided e.g. outputs/daily-test"
+            "'OUTPUT_DIR' environment variable must be set e.g. outputs/daily-test"
         )
         sys.exit(1)
 

--- a/scripts/get_stress_test_summary.py
+++ b/scripts/get_stress_test_summary.py
@@ -1,7 +1,7 @@
 import os
 import statistics
-import sys
 from glob import glob
+from scripts.get_stats import get_stats
 
 
 def get_results(folders):
@@ -9,41 +9,25 @@ def get_results(folders):
     results = {
         "get": [],
         "post": [],
-        "average_get": None,
-        "average_post": None,
-        "average_total": None,
+        "average_get": [],
+        "average_post": [],
+        "average_total": [],
+        "error_percentage": 0,
         "total_requests": 0,
-        "total_failures": 0,
-        "error_percentage": 0
+        "total_failures": 0
     }
 
     for folder in folders:
-        for file in glob(folder + '/*stats.csv'):
+        stats = get_stats(folder)
+        results["get"].extend(stats["get"])
+        results["post"].extend(stats["post"])
+        results["total_requests"] = results["total_requests"] + stats["total_requests"]
+        results["total_failures"] = results["total_failures"] + stats["total_failures"]
 
-            with open(file) as f:
-                data = f.read()
-
-            for line in data.split('\n'):
-                if 'Name' in line:
-                    continue
-
-                values = line.split(',')
-
-                percentile_99th = int(values[18])
-                if values[1].startswith('"/questionnaire'):
-                    if values[0] == '"GET"':
-                        results["get"].append(percentile_99th)
-                    elif values[0] == '"POST"':
-                        results["post"].append(percentile_99th)
-
-                if 'Aggregated' in line:
-                    results["total_requests"] = results["total_requests"] + int(values[2])
-                    results["total_failures"] = results["total_failures"] + int(values[3])
-
-        results["average_get"] = statistics.mean(results["get"])
-        results["average_post"] = statistics.mean(results["post"])
-        results["average_total"] = statistics.mean(results["get"] + results["post"])
-        results["error_percentage"] = (results["total_failures"] * 100) / results["total_requests"]
+    results["average_get"] = statistics.mean(results["get"])
+    results["average_post"] = statistics.mean(results["post"])
+    results["average_total"] = statistics.mean(results["get"] + results["post"])
+    results["error_percentage"] = (results["total_failures"] * 100) / results["total_requests"]
 
     return results
 

--- a/scripts/get_stress_test_summary.py
+++ b/scripts/get_stress_test_summary.py
@@ -33,18 +33,14 @@ def get_results(folders):
     return results
 
 
-def parse_environment_variables():
-    try:
-        output_dir = os.environ["OUTPUT_DIR"]
-    except KeyError:
-        print("'OUTPUT_DIR' environment variable must be set e.g. outputs/daily-test")
-        sys.exit(1)
-
-    return output_dir
-
-
 if __name__ == "__main__":
-    folder = parse_environment_variables()
+    folder = os.getenv("OUTPUT_DIR")
+
+    if not folder:
+        print(
+            "'OUTPUT_DIR' environment variable must be provided e.g. outputs/daily-test"
+        )
+        sys.exit(1)
 
     sorted_folders = sorted(glob(f"{folder}/*"))
     result = get_results(sorted_folders)

--- a/scripts/get_summary.py
+++ b/scripts/get_summary.py
@@ -68,5 +68,4 @@ if __name__ == "__main__":
                 print(result[1])
                 break
         else:
-            print(result[0])
-            print(result[1])
+            print(f"{result[0]}\n" f"{result[1]}\n")

--- a/scripts/get_summary.py
+++ b/scripts/get_summary.py
@@ -13,7 +13,7 @@ def get_results(folders, number_of_days=None):
     )
 
     for folder in folders:
-        date = folder.split('/')[-1].split('T')[0]
+        date = folder.split("/")[-1].split("T")[0]
         if from_date and datetime.strptime(date, "%Y-%m-%d") < from_date:
             continue
 
@@ -35,7 +35,7 @@ def get_results(folders, number_of_days=None):
                 statistics.mean(all_response_times),
                 stats["total_requests"],
                 stats["total_failures"],
-                (stats["total_failures"] * 100) / stats["total_requests"]
+                (stats["total_failures"] * 100) / stats["total_requests"],
             ]
         )
 
@@ -60,27 +60,27 @@ def parse_environment_variables():
     output_date = os.getenv("OUTPUT_DATE")
 
     return {
-        'output_dir': output_dir,
-        'number_of_days': days,
-        'output_date': output_date,
+        "output_dir": output_dir,
+        "number_of_days": days,
+        "output_date": output_date,
     }
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parsed_variables = parse_environment_variables()
-    date_to_output = parsed_variables['output_date']
+    date_to_output = parsed_variables["output_date"]
 
     sorted_folders = sorted(glob(f"{parsed_variables['output_dir']}/*"))
     result = get_results(sorted_folders)
 
     for result in result[::-1]:
         summary = (
-            f'Questionnaire GETs average: {int(result[1])}ms\n'
-            f'Questionnaire POSTs average: {int(result[2])}ms\n'
-            f'All requests average: {int(result[3])}ms\n'
-            f'Total Requests: {int(result[4])}\n'
-            f'Total Failures: {int(result[5])}\n'
-            f'Error Percentage {(round(result[6], 2))}%'
+            f"Questionnaire GETs average: {int(result[1])}ms\n"
+            f"Questionnaire POSTs average: {int(result[2])}ms\n"
+            f"All requests average: {int(result[3])}ms\n"
+            f"Total Requests: {int(result[4])}\n"
+            f"Total Failures: {int(result[5])}\n"
+            f"Error Percentage: {(round(result[6], 2))}%"
         )
 
         if date_to_output:
@@ -88,4 +88,4 @@ if __name__ == '__main__':
                 print(summary)
                 break
         else:
-            print(f'{result[0]}\n' f'{summary}\n')
+            print(f"{result[0]}\n" f"{summary}\n")

--- a/scripts/get_summary.py
+++ b/scripts/get_summary.py
@@ -22,10 +22,10 @@ def get_results(folders, number_of_days=None):
 
         stats = get_stats(folder)
 
-        get_request_response_times.extend(stats["get"])
-        post_request_response_times.extend(stats["post"])
+        get_request_response_times.extend(stats.get)
+        post_request_response_times.extend(stats.post)
 
-        all_response_times = stats["get"] + stats["post"]
+        all_response_times = stats.get + stats.post
 
         results_list.append(
             [
@@ -33,9 +33,9 @@ def get_results(folders, number_of_days=None):
                 statistics.mean(get_request_response_times),
                 statistics.mean(post_request_response_times),
                 statistics.mean(all_response_times),
-                stats["total_requests"],
-                stats["total_failures"],
-                (stats["total_failures"] * 100) / stats["total_requests"],
+                stats.total_requests,
+                stats.total_failures,
+                (stats.total_failures * 100) / stats.total_requests,
             ]
         )
 

--- a/scripts/visualise_results.py
+++ b/scripts/visualise_results.py
@@ -22,6 +22,10 @@ if __name__ == '__main__':
 
     folders = sorted(glob(f"{parsed_variables['output_dir']}/*"))
     results = get_results(folders, parsed_variables['number_of_days'])
-    data_frame = DataFrame(results, columns=["DATE", "GET", "POST", "AVERAGE"])
+    result_fields = []
+    for result in results:
+        result_fields.append([result[0], result[1].average_get, result[1].average_post, result[1].average_total])
+
+    data_frame = DataFrame(result_fields, columns=["DATE", "GET", "POST", "AVERAGE"])
 
     plot_data(data_frame)

--- a/scripts/visualise_results.py
+++ b/scripts/visualise_results.py
@@ -22,9 +22,15 @@ if __name__ == '__main__':
 
     folders = sorted(glob(f"{parsed_variables['output_dir']}/*"))
     results = get_results(folders, parsed_variables['number_of_days'])
-    result_fields = []
-    for result in results:
-        result_fields.append([result[0], result[1].average_get, result[1].average_post, result[1].average_total])
+    result_fields = [
+        [
+            result[0],
+            result[1].average_get,
+            result[1].average_post,
+            result[1].average_total,
+        ]
+        for result in results
+    ]
 
     data_frame = DataFrame(result_fields, columns=["DATE", "GET", "POST", "AVERAGE"])
 


### PR DESCRIPTION
### What is the context of this PR?
Adds the `get_stress_test_summary` script which provides aggregate performance results at the folder level.

Currently the following variables are included in the output (example):
```
Questionnaire GETs average: 465ms
Questionnaire POSTs average: 525ms
All requests average: 495ms
Total Requests: 30056523
Total Failures: 140186
Error Percentage: 0.47%
```
### How to review 
Download the latest benchmark results and get aggregated results by running:
`OUTPUT_DIR="outputs/daily-test" pipenv run python -m scripts.get_stress_test_summary`

Check that the output is correct. Are there any variables that need to be added?
