### PR TITLE
Fix census benchmark for v0.26.0 schema release

### DIFF
--- a/requests/census_household_gb_eng.json
+++ b/requests/census_household_gb_eng.json
@@ -562,7 +562,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_1_list_id}/gcse/",
             "data": {
-                "gcse-answer": "5 or more GCSEs grades A* to C or 9 to 4"
+                "gcse-answer": "5 or more GCSEs grade A* to C or 9 to 4"
             }
         },
         {
@@ -1016,7 +1016,7 @@
             "method": "POST",
             "url": "/questionnaire/household/{person_2_list_id}/gcse/",
             "data": {
-                "gcse-answer": "5 or more GCSEs grades A* to C or 9 to 4"
+                "gcse-answer": "5 or more GCSEs grade A* to C or 9 to 4"
             }
         },
         {

--- a/requests/census_individual_gb_eng.json
+++ b/requests/census_individual_gb_eng.json
@@ -339,7 +339,7 @@
             "method": "POST",
             "url": "/questionnaire/gcse/",
             "data": {
-                "gcse-answer": "5 or more GCSEs grades A* to C or 9 to 4"
+                "gcse-answer": "5 or more GCSEs grade A* to C or 9 to 4"
             }
         },
         {


### PR DESCRIPTION
### What is the context of this PR?
The benchmark has been broken by a recent schema change. This pull request fixes the issue.

### How to review 
Run the census household and individual requests files against a runner instance using v0.26.0 schemas.
