### PR TITLE
Display latest summary when date to output is provided

### DIFF
--- a/scripts/get_summary.py
+++ b/scripts/get_summary.py
@@ -54,7 +54,7 @@ def parse_environment_variables():
 if __name__ == "__main__":
     parsed_variables = parse_environment_variables()
     date_to_output = parsed_variables["output_date"]
-    sorted_folders = sorted(glob(f"{parsed_variables['output_dir']}/*"))
+    sorted_folders = sorted(glob(f"{parsed_variables['output_dir']}/*"), reverse=True)
     results = get_results(sorted_folders)
 
     for result in results:


### PR DESCRIPTION
### What is the context of this PR?
The recent refactors introduced a bug where when you provide a date to output summary for, it will output the first result instead of the latest result for the given date.
This change ensures the latest run for a given date is returned.

### How to review 
Ensure the latest summary is shown when a given date has multiple test runs.

Alternatively:
- Authorise with gcloud
- Fetch the latest data: `➜ OUTPUT_BUCKET="eq-daily-performance-test-benchmark-outputs" pipenv run python -m scripts.get_benchmark_results`
- Output summary for `2020-08-04` which has multiple runs. `➜ OUTPUT_DIR="outputs/daily-test" OUTPUT_DATE=2020-08-04 pipenv run python -m scripts.get_summary`
- Delete the data for one of the runs and ensure the summary updates accordingly.