### PR TITLE
Benchmark to include request weighting

### DIFF
--- a/scripts/benchmark_stats.py
+++ b/scripts/benchmark_stats.py
@@ -13,15 +13,14 @@ class BenchmarkStats:
         self.weighted_post_requests: List[int] = []
         self.total_get_requests: int = 0
         self.total_post_requests: int = 0
-        self.total_requests: int = 0
         self.total_failures: int = 0
         self._process_file_data()
 
     def __str__(self):
         return (
-            f'Questionnaire GETs average: {int(self.average_get)}ms\n'
-            f'Questionnaire POSTs average: {int(self.average_post)}ms\n'
-            f'All requests average: {int(self.average_total)}ms\n'
+            f'Questionnaire GETs average: {int(self.average_weighted_get)}ms\n'
+            f'Questionnaire POSTs average: {int(self.average_weighted_post)}ms\n'
+            f'All requests average: {int(self.average_weighted_total)}ms\n'
             f'Total Requests: {int(self.total_requests):,}\n'
             f'Total Failures: {int(self.total_failures):,}\n'
             f'Error Percentage: {(round(self.error_percentage, 2))}%\n'
@@ -39,12 +38,11 @@ class BenchmarkStats:
                             self.weighted_get_requests.append(percentile_99th * request_count)
                             self.total_get_requests += request_count
                         elif row["Type"] == "POST":
-                            self.weighted_post_requests += request_count
-                            self.post_requests.append(percentile_99th * request_count)
+                            self.weighted_post_requests.append(percentile_99th * request_count)
+                            self.total_post_requests += request_count
 
                     if row["Name"] == "Aggregated":
                         failure_count = row.get("Failure Count") or row.get("# failures")
-                        self.total_requests += request_count
                         self.total_failures += int(failure_count)
 
     @property
@@ -61,8 +59,12 @@ class BenchmarkStats:
 
     @property
     def average_weighted_total(self):
-        return sum(self.weighted_get_requests + self.weighted_post_requests) / (self.total_post_requests + self.total_get_requests)
+        return sum(self.weighted_get_requests + self.weighted_post_requests) / self.total_post_requests
 
     @property
     def error_percentage(self):
         return (self.total_failures * 100) / self.total_requests
+
+    @property
+    def total_requests(self):
+        return self.total_get_requests + self.total_post_requests

--- a/scripts/benchmark_stats.py
+++ b/scripts/benchmark_stats.py
@@ -12,8 +12,8 @@ class BenchmarkStats:
 
         self.get_requests: List[int] = []
         self.post_requests: List[int] = []
-        self.total_get_requests = 0
-        self.total_post_requests = 0
+        self.total_get_requests: int = 0
+        self.total_post_requests: int = 0
         self.total_requests: int = 0
         self.total_failures: int = 0
         self._process_file_data()

--- a/scripts/benchmark_stats.py
+++ b/scripts/benchmark_stats.py
@@ -1,6 +1,5 @@
 from csv import DictReader
 from glob import glob
-from statistics import mean
 from typing import List
 
 

--- a/scripts/benchmark_stats.py
+++ b/scripts/benchmark_stats.py
@@ -9,8 +9,8 @@ class BenchmarkStats:
         for folder_path in folder_paths:
             self._files.extend(glob(f"{folder_path}/*stats.csv"))
 
-        self.get_requests: List[int] = []
-        self.post_requests: List[int] = []
+        self.weighted_get_requests: List[int] = []
+        self.weighted_post_requests: List[int] = []
         self.total_get_requests: int = 0
         self.total_post_requests: int = 0
         self.total_requests: int = 0
@@ -36,10 +36,10 @@ class BenchmarkStats:
 
                     if "/questionnaire" in row['Name']:
                         if row["Type"] == "GET":
-                            self.get_requests.append(percentile_99th * request_count)
+                            self.weighted_get_requests.append(percentile_99th * request_count)
                             self.total_get_requests += request_count
                         elif row["Type"] == "POST":
-                            self.total_post_requests += request_count
+                            self.weighted_post_requests += request_count
                             self.post_requests.append(percentile_99th * request_count)
 
                     if row["Name"] == "Aggregated":
@@ -52,16 +52,16 @@ class BenchmarkStats:
         return self._files
 
     @property
-    def average_get(self):
-        return sum(self.get_requests)/self.total_get_requests
+    def average_weighted_get(self):
+        return sum(self.weighted_get_requests) / self.total_get_requests
 
     @property
-    def average_post(self):
-        return sum(self.post_requests)/self.total_post_requests
+    def average_weighted_post(self):
+        return sum(self.weighted_post_requests) / self.total_post_requests
 
     @property
-    def average_total(self):
-        return sum(self.post_requests + self.get_requests)/(self.total_post_requests + self.total_get_requests)
+    def average_weighted_total(self):
+        return sum(self.weighted_get_requests + self.weighted_post_requests) / (self.total_post_requests + self.total_get_requests)
 
     @property
     def error_percentage(self):

--- a/scripts/benchmark_stats.py
+++ b/scripts/benchmark_stats.py
@@ -32,16 +32,16 @@ class BenchmarkStats:
         for file in self.files:
             with open(file) as fp:
                 for row in DictReader(fp, delimiter=","):
-                    percentile_99_9th = int(row["99.9%"])
+                    percentile_99th = int(row["99%"])
                     request_count = int(row.get("Request Count") or row.get("# requests"))
 
                     if "/questionnaire" in row['Name']:
                         if row["Type"] == "GET":
-                            self.get_requests.append(percentile_99_9th * request_count)
+                            self.get_requests.append(percentile_99th * request_count)
                             self.total_get_requests += request_count
                         elif row["Type"] == "POST":
                             self.total_post_requests += request_count
-                            self.post_requests.append(percentile_99_9th * request_count)
+                            self.post_requests.append(percentile_99th * request_count)
 
                     if row["Name"] == "Aggregated":
                         failure_count = row.get("Failure Count") or row.get("# failures")


### PR DESCRIPTION
### What is the context of this PR?
Our benchmark currently doesn't include request weighting, this will distort the results as different endpoints can get different volumes of requests.

N.B - There are a number of other improvements that can be made to these results, and I will stick a card in tech session to discuss, but haven't looked to change them on this PR. They include not including session and thank you GETS in any of our figures and splitting up the results on known pinch points (i.e. grouping features rather than our current aggregating everything)

### How to review 
Run a test and check benchmark_stats returns the expected figures.
