### PR TITLE
Filter benchmark results download by number of days

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ OUTPUT_BUCKET="<bucket_name>" pipenv run python -m scripts.get_benchmark_results
 This script also accepts optional `NUMBER_OF_DAYS` and `OUTPUT_DIR` environment variables which allows the user to download a subset of results and set
 a specific output directory e.g.
 ```bash
-OUTPUT_BUCKET="<bucket_name>" NUMBER_OF_DAYS=30 OUTPUT_DIR="<output_directory>" pipenv run python -m scripts.get_benchmark_results
+OUTPUT_BUCKET="<bucket_name>" NUMBER_OF_DAYS=<number_of_days> OUTPUT_DIR="<output_directory>" pipenv run python -m scripts.get_benchmark_results
 ```
 
 ### Summarise the Daily Benchmark results

--- a/README.md
+++ b/README.md
@@ -200,6 +200,12 @@ To run the script and download results:
 OUTPUT_BUCKET="<bucket_name>" pipenv run python -m scripts.get_benchmark_results
 ```
 
+This script also accepts optional `NUMBER_OF_DAYS` and `OUTPUT_DIR` environment variables which allows the user to download a subset of results and set
+a specific output directory e.g.
+```bash
+OUTPUT_BUCKET="<bucket_name>" NUMBER_OF_DAYS=30 OUTPUT_DIR="<output_directory>" pipenv run python -m scripts.get_benchmark_results
+```
+
 ### Summarise the Daily Benchmark results
 You can get a breakdown of the average response times for a result set by doing:
 ```bash

--- a/ci/output-results-to-slack.yaml
+++ b/ci/output-results-to-slack.yaml
@@ -31,6 +31,8 @@ run:
 
       # Get benchmark outputs
       OUTPUT_BUCKET="$OUTPUT_BUCKET" \
+      OUTPUT_DIR="outputs" \
+      NUMBER_OF_DAYS="$NUMBER_OF_DAYS" \
       pipenv run python -m scripts.get_benchmark_results
 
       # Create performance graph

--- a/scripts/get_benchmark_results.py
+++ b/scripts/get_benchmark_results.py
@@ -15,7 +15,7 @@ if __name__ == '__main__':
     from_date = None
 
     if number_of_days:
-        from_date = (datetime.utcnow() - timedelta(days=number_of_days))
+        from_date = datetime.utcnow() - timedelta(days=number_of_days)
 
     if not output_bucket:
         print("'OUTPUT_BUCKET' environment variable must be provided")

--- a/scripts/get_benchmark_results.py
+++ b/scripts/get_benchmark_results.py
@@ -11,6 +11,7 @@ if __name__ == '__main__':
 
     parsed_variables = parse_environment_variables()
     number_of_days = parsed_variables['number_of_days']
+    output_dir = parsed_variables['output_dir']
 
     from_date = None
 
@@ -24,5 +25,5 @@ if __name__ == '__main__':
     gcs = GoogleCloudStorage(bucket_name=output_bucket)
     print("Fetching files...")
 
-    gcs.get_files(from_date=from_date)
+    gcs.get_files(from_date=from_date, output_dir=output_dir)
     print('All files downloaded')

--- a/scripts/get_benchmark_results.py
+++ b/scripts/get_benchmark_results.py
@@ -14,10 +14,11 @@ if __name__ == '__main__':
     number_of_days = parsed_variables['number_of_days']
     output_dir = parsed_variables['output_dir']
 
-    from_date = None
-
-    if number_of_days:
-        from_date = datetime.now(tz=tzutc()) - timedelta(days=number_of_days)
+    from_date = (
+        datetime.now(tz=tzutc()) - timedelta(days=number_of_days)
+        if number_of_days
+        else None
+    )
 
     if not output_bucket:
         print("'OUTPUT_BUCKET' environment variable must be provided")

--- a/scripts/get_benchmark_results.py
+++ b/scripts/get_benchmark_results.py
@@ -1,17 +1,14 @@
 import os
 import sys
 
+from scripts.get_summary import parse_environment_variables
 from scripts.google_cloud_storage import GoogleCloudStorage
 
 if __name__ == '__main__':
     output_bucket = os.getenv("OUTPUT_BUCKET")
 
-    days = os.getenv("NUMBER_OF_DAYS")
-    if days and days.isdigit() is False:
-        print("'NUMBER_OF_DAYS' environment variable must be a valid integer value")
-        sys.exit(1)
-
-    days = int(days) if days else None
+    parsed_variables = parse_environment_variables()
+    number_of_days = parsed_variables['number_of_days']
 
     if not output_bucket:
         print("'OUTPUT_BUCKET' environment variable must be provided")
@@ -20,5 +17,5 @@ if __name__ == '__main__':
     gcs = GoogleCloudStorage(bucket_name=output_bucket)
     print("Fetching files...")
 
-    gcs.get_files(number_of_days=days)
+    gcs.get_files(number_of_days=number_of_days)
     print('All files downloaded')

--- a/scripts/get_benchmark_results.py
+++ b/scripts/get_benchmark_results.py
@@ -6,6 +6,13 @@ from scripts.google_cloud_storage import GoogleCloudStorage
 if __name__ == '__main__':
     output_bucket = os.getenv("OUTPUT_BUCKET")
 
+    days = os.getenv("NUMBER_OF_DAYS")
+    if days and days.isdigit() is False:
+        print("'NUMBER_OF_DAYS' environment variable must be a valid integer value")
+        sys.exit(1)
+
+    days = int(days) if days else None
+
     if not output_bucket:
         print("'OUTPUT_BUCKET' environment variable must be provided")
         sys.exit(1)
@@ -13,5 +20,5 @@ if __name__ == '__main__':
     gcs = GoogleCloudStorage(bucket_name=output_bucket)
     print("Fetching files...")
 
-    gcs.get_files()
+    gcs.get_files(number_of_days=days)
     print('All files downloaded')

--- a/scripts/get_benchmark_results.py
+++ b/scripts/get_benchmark_results.py
@@ -2,6 +2,7 @@ import os
 import sys
 
 from datetime import datetime, timedelta
+from dateutil.tz import tzutc
 
 from scripts.get_summary import parse_environment_variables
 from scripts.google_cloud_storage import GoogleCloudStorage
@@ -16,7 +17,7 @@ if __name__ == '__main__':
     from_date = None
 
     if number_of_days:
-        from_date = datetime.utcnow() - timedelta(days=number_of_days)
+        from_date = datetime.now(tz=tzutc()) - timedelta(days=number_of_days)
 
     if not output_bucket:
         print("'OUTPUT_BUCKET' environment variable must be provided")

--- a/scripts/get_benchmark_results.py
+++ b/scripts/get_benchmark_results.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+from datetime import datetime, timedelta
+
 from scripts.get_summary import parse_environment_variables
 from scripts.google_cloud_storage import GoogleCloudStorage
 
@@ -10,6 +12,11 @@ if __name__ == '__main__':
     parsed_variables = parse_environment_variables()
     number_of_days = parsed_variables['number_of_days']
 
+    from_date = None
+
+    if number_of_days:
+        from_date = (datetime.utcnow() - timedelta(days=number_of_days))
+
     if not output_bucket:
         print("'OUTPUT_BUCKET' environment variable must be provided")
         sys.exit(1)
@@ -17,5 +24,5 @@ if __name__ == '__main__':
     gcs = GoogleCloudStorage(bucket_name=output_bucket)
     print("Fetching files...")
 
-    gcs.get_files(number_of_days=number_of_days)
+    gcs.get_files(from_date=from_date)
     print('All files downloaded')

--- a/scripts/get_summary.py
+++ b/scripts/get_summary.py
@@ -28,10 +28,6 @@ def get_results(folders, number_of_days=None):
 
 
 def parse_environment_variables():
-    output_dir = os.getenv("OUTPUT_DIR")
-
-    if not output_dir:
-        output_dir = "outputs"
 
     days = os.getenv("NUMBER_OF_DAYS")
     if days and days.isdigit() is False:
@@ -39,12 +35,11 @@ def parse_environment_variables():
         sys.exit(1)
 
     days = int(days) if days else None
-    output_date = os.getenv("OUTPUT_DATE")
 
     return {
-        "output_dir": output_dir,
         "number_of_days": days,
-        "output_date": output_date,
+        "output_date": os.getenv("OUTPUT_DATE"),
+        "output_dir": os.getenv("OUTPUT_DIR", "outputs"),
     }
 
 

--- a/scripts/get_summary.py
+++ b/scripts/get_summary.py
@@ -31,10 +31,7 @@ def parse_environment_variables():
     output_dir = os.getenv("OUTPUT_DIR")
 
     if not output_dir:
-        print(
-            "'OUTPUT_DIR' environment variable must be provided e.g. outputs/daily-test"
-        )
-        sys.exit(1)
+        output_dir = "outputs"
 
     days = os.getenv("NUMBER_OF_DAYS")
     if days and days.isdigit() is False:

--- a/scripts/google_cloud_storage.py
+++ b/scripts/google_cloud_storage.py
@@ -1,7 +1,7 @@
 import os
 import json
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from google.cloud import storage
 
 
@@ -25,14 +25,8 @@ class GoogleCloudStorage:
             blob.metadata = {**kwargs}
             blob.upload_from_filename(filename=output_file)
 
-    def get_files(self, number_of_days):
-        output_dir = "outputs"
-
-        from_date = (
-            (datetime.utcnow() - timedelta(days=number_of_days))
-            if number_of_days
-            else None
-        )
+    def get_files(self, from_date):
+        output_dir = os.getenv("OUTPUT_DIR")
 
         for blob in self.client.list_blobs(self.bucket_name):
             blob_date = blob.name.split("/")[1].split("T")[0]

--- a/scripts/google_cloud_storage.py
+++ b/scripts/google_cloud_storage.py
@@ -28,9 +28,8 @@ class GoogleCloudStorage:
     def get_files(self, from_date, output_dir):
 
         for blob in self.client.list_blobs(self.bucket_name):
-            blob_date = blob.name.split("/")[1].split("T")[0]
 
-            if from_date and datetime.strptime(blob_date, "%Y-%m-%d") < from_date:
+            if from_date and blob.time_created < from_date:
                 continue
 
             file_path = blob.name.rsplit('/', 1)[0]

--- a/scripts/google_cloud_storage.py
+++ b/scripts/google_cloud_storage.py
@@ -1,7 +1,6 @@
 import os
 import json
 
-from datetime import datetime
 from google.cloud import storage
 
 

--- a/scripts/google_cloud_storage.py
+++ b/scripts/google_cloud_storage.py
@@ -25,8 +25,7 @@ class GoogleCloudStorage:
             blob.metadata = {**kwargs}
             blob.upload_from_filename(filename=output_file)
 
-    def get_files(self, from_date):
-        output_dir = os.getenv("OUTPUT_DIR")
+    def get_files(self, from_date, output_dir):
 
         for blob in self.client.list_blobs(self.bucket_name):
             blob_date = blob.name.split("/")[1].split("T")[0]

--- a/scripts/google_cloud_storage.py
+++ b/scripts/google_cloud_storage.py
@@ -1,6 +1,7 @@
 import os
 import json
 
+from datetime import datetime, timedelta
 from google.cloud import storage
 
 
@@ -24,10 +25,18 @@ class GoogleCloudStorage:
             blob.metadata = {**kwargs}
             blob.upload_from_filename(filename=output_file)
 
-    def get_files(self):
+    def get_files(self, number_of_days):
         output_dir = "outputs"
 
         for blob in self.client.list_blobs(self.bucket_name):
+            blob_date = blob.name.split("/")[1].split("T")[0]
+
+            from_date = (
+                (datetime.utcnow() - timedelta(days=number_of_days)) if number_of_days else None
+            )
+
+            if from_date and datetime.strptime(blob_date, "%Y-%m-%d") < from_date:
+                continue
 
             file_path = blob.name.rsplit('/', 1)[0]
 

--- a/scripts/google_cloud_storage.py
+++ b/scripts/google_cloud_storage.py
@@ -32,7 +32,9 @@ class GoogleCloudStorage:
             blob_date = blob.name.split("/")[1].split("T")[0]
 
             from_date = (
-                (datetime.utcnow() - timedelta(days=number_of_days)) if number_of_days else None
+                (datetime.utcnow() - timedelta(days=number_of_days))
+                if number_of_days
+                else None
             )
 
             if from_date and datetime.strptime(blob_date, "%Y-%m-%d") < from_date:

--- a/scripts/google_cloud_storage.py
+++ b/scripts/google_cloud_storage.py
@@ -28,14 +28,14 @@ class GoogleCloudStorage:
     def get_files(self, number_of_days):
         output_dir = "outputs"
 
+        from_date = (
+            (datetime.utcnow() - timedelta(days=number_of_days))
+            if number_of_days
+            else None
+        )
+
         for blob in self.client.list_blobs(self.bucket_name):
             blob_date = blob.name.split("/")[1].split("T")[0]
-
-            from_date = (
-                (datetime.utcnow() - timedelta(days=number_of_days))
-                if number_of_days
-                else None
-            )
 
             if from_date and datetime.strptime(blob_date, "%Y-%m-%d") < from_date:
                 continue


### PR DESCRIPTION
### What is the context of this PR?
Adds the ability to filter the benchmark results download from the GCS bucket by number of days. This can be done by running the `get_benchmark_results` script with the optional `NUMBER_OF_DAYS` environment variable set.

### How to review 
Run the `get_benchmark_results` script with the `NUMBER_OF_DAYS` environment variable set e.g.

`OUTPUT_BUCKET="eq-daily-performance-test-benchmark-outputs" NUMBER_OF_DAYS=5  pipenv run python -m scripts.get_benchmark_results` 
