### PR TITLE
Remove deprecated set-env command

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          echo "::set-env name=PYTHON_VERSION::$(cat .python-version)"
+          echo "PYTHON_VERSION=$(cat .python-version)" >> $GITHUB_ENV
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Tag
-        run: echo "::set-env name=TAG::${{ github.event.pull_request.head.ref }}"
+        run: echo "TAG=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
       - name: Build
         run: docker build -t onsdigital/eq-survey-runner-benchmark:$TAG .
       - name: Push


### PR DESCRIPTION
### What is the context of this PR?
Removes the `set-env` command from GitHub actions workflow files

### How to review 
Describe the steps required to test the changes (include screenshots if appropriate).
