### PR TITLE
Use randint instead of randrange

### DIFF
--- a/runner_benchmark/taskset.py
+++ b/runner_benchmark/taskset.py
@@ -53,7 +53,7 @@ class SurveyRunnerTaskSet(TaskSet, QuestionnaireMixins):
                     self.handle_redirect(request, response)
 
                 if user_wait_time_min and user_wait_time_max:
-                    time.sleep(r.randrange(user_wait_time_min, user_wait_time_max))
+                    time.sleep(r.randint(user_wait_time_min, user_wait_time_max))
 
             elif request['method'] == 'POST':
                 response = self.post(


### PR DESCRIPTION
### What is the context of this PR?

Updates `time.sleep(r.randrange(user_wait_time_min, user_wait_time_max))` to use `randint` rather than `randrange`.

This changes the random `wait time` generation in order to fix a bug in our daily benchmark tests. `randrange` was exclusive so when the minimum wait time was 1 and max was 2, the wait was always being set to 1.

### How to review 
This PR is dependent on the following `eq-pipelines` [PR](https://github.com/ONSdigital/eq-pipelines/pull/118) which updates the number of users in the Locust test.

To test the change run a benchmark test with this branch against a test environment using the `eq-pipelines` branch above with the  modified number of users and check that the results are consistent with historic runs.

Our tests showed that the changes were consistent with runs using randrage but were a more stable. 

First 6 results use `randrange` with `96` users, Last 4 use `randint` with `144` users:

![image](https://user-images.githubusercontent.com/47635349/101784075-f4e3d280-3af2-11eb-9a23-185661708dec.png)


