### PR TITLE
Add Email confirmation and Feedback to household journey

### DIFF
--- a/requests/census_household_gb_eng.json
+++ b/requests/census_household_gb_eng.json
@@ -1282,6 +1282,35 @@
         {
             "method": "GET",
             "url": "/submitted/thank-you/"
+        },
+        {
+            "method": "POST",
+            "url": "/submitted/thank-you/",
+            "data": {
+                "email": "test@email.com"
+            },
+            "redirect_route": "/submitted/confirmation-email/sent?email={email}"
+        },
+        {
+            "method": "GET",
+            "url": "/submitted/confirmation-email/sent?email={email}"
+        },
+        {
+            "method": "GET",
+            "url": "/submitted/feedback/send"
+        },
+        {
+            "method": "POST",
+            "url": "/submitted/feedback/send",
+            "data": {
+                "feedback-type": "The census questions",
+                "feedback-type-question-category": "General",
+                "feedback-text": "Test feedback"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/submitted/feedback/sent"
         }
     ],
     "schema_name": "census_household_gb_eng"

--- a/requests/census_household_gb_eng.json
+++ b/requests/census_household_gb_eng.json
@@ -1287,7 +1287,7 @@
             "method": "POST",
             "url": "/submitted/thank-you/",
             "data": {
-                "email": "test@email.com"
+                "email": "simulate-delivered@notifications.service.gov.uk"
             },
             "redirect_route": "/submitted/confirmation-email/sent?email={email}"
         },


### PR DESCRIPTION
### What is the context of this PR?
This PR adds a single email confirmation and a single feedback submission to the household benchmark journey.

### How to review 
Run the benchmark script against your local or a GCP environment and make sure it works (pipenv run ./run.sh requests/census_household_gb_eng.json)
