### PR TITLE
Remove questionnaire_id

### DIFF
--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -21,7 +21,6 @@ PAYLOAD = {
     'case_type': 'HI',
     'display_address': '68 Abingdon Road, Goathill',
     'ru_ref': '123456789012A',
-    'questionnaire_id': '0123456789000000',
     'ru_name': 'Integration Testing',
     'ref_p_start_date': '2019-04-01',
     'ref_p_end_date': '2019-011-30',


### PR DESCRIPTION
### What is the context of this PR?
questionnaire_id is a census specific and therefore can now be removed

### How to review 
Make sure benchmark still works with the new update in [runner](https://github.com/ONSdigital/eq-questionnaire-runner/pull/607)