### PR TITLE
Update Slack authorisation token

### DIFF
--- a/ci/output-results-to-slack.yaml
+++ b/ci/output-results-to-slack.yaml
@@ -12,7 +12,7 @@ params:
   SLACK_CHANNEL_NAME:
   NUMBER_OF_DAYS:
   SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-  SLACK_AUTH_TOKEN: ((eq-census-slack-app.bot_user_oauth_token))
+  SLACK_AUTH_TOKEN: ((eq-ons-slack-app.bot_user_oauth_token))
 run:
   path: bash
   args:


### PR DESCRIPTION
### What is the context of this PR?
This updates Slack authorisation token to our non-census specific one, used in the new Concourse, to communicate between pipelines and slack.

### How to review 
Check if you can post alerts to `eq-dev-team` or similar channel from your pipeline.