### PR TITLE
Add buiness benchmark request file

### DIFF
--- a/requests/test_benchmark_business.json
+++ b/requests/test_benchmark_business.json
@@ -1,0 +1,130 @@
+{
+    "requests": [
+        {
+            "method": "GET",
+            "url": "/questionnaire/introduction-block/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/introduction-block/",
+            "data": {}
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/block379/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/block379/",
+            "data": {
+                "answer434": "No"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/block380/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/block380/",
+            "data": {
+                "answerfrom-day": "1",
+                "answerfrom-month": "05",
+                "answerfrom-year": "2019",
+                "answerto-day": "1",
+                "answerto-month": "08",
+                "answerto-year": "2019"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/block381/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/block381/",
+            "data": {
+                "answer436": "100",
+                "answer437": "100"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/block4616/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/block4616/",
+            "data": {
+                "answer5873": "Yes"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/block4952/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/block4952/",
+            "data": {
+                "answer6287": "Yes"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/block4953/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/block4953/",
+            "data": {
+                "answer6288": "One-off increase in stocks"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/block383/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/block383/",
+            "data": {
+                "answer439": "Differences textarea"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/questionnaire/submit/"
+        },
+        {
+            "method": "POST",
+            "url": "/questionnaire/submit/",
+            "data": {}
+        },
+        {
+            "method": "GET",
+            "url": "/submitted/thank-you/"
+        },
+        {
+            "method": "GET",
+            "url": "/submitted/feedback/send"
+        },
+        {
+            "method": "POST",
+            "url": "/submitted/feedback/send",
+            "data": {
+                "feedback-type": "The survey questions",
+                "feedback-text": "Feedback"
+            }
+        },
+        {
+            "method": "GET",
+            "url": "/submitted/feedback/sent"
+        },
+        {
+            "method": "GET",
+            "url": "/submitted/thank-you/"
+        }
+    ],
+    "schema_name": "test_benchmark_business"
+}

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -23,7 +23,7 @@ PAYLOAD = {
     'ru_ref': '123456789012A',
     'ru_name': 'Integration Testing',
     'ref_p_start_date': '2019-04-01',
-    'ref_p_end_date': '2019-011-30',
+    'ref_p_end_date': '2019-11-30',
     'return_by': '2019-12-06',
     'trad_as': 'Benchmark Tests',
     'employment_date': '1983-06-02',


### PR DESCRIPTION
### What is the context of this PR?
This PR add the request file for business. There are only 2 routing rules in the questionnaire and I have answered so every block is visited. I have also included a trip to the feedback page.

### How to review 
You will need runner to be using this branch, add-benchmark-business-schema  https://github.com/ONSdigital/eq-questionnaire-runner/pull/730. Then its a case of just running a test and making sure everything works as expected
```
pipenv run ./run.sh requests/test_benchmark_business.json
```