### PR TITLE
Remove output bucket var in run_benchmark script

### DIFF
--- a/ci/README.md
+++ b/ci/README.md
@@ -23,7 +23,6 @@ The following env vars must be set:
 - PARALLELISM
 - TIMEOUT
 - OUTPUT_DIR
-- OUTPUT_BUCKET
 
 IMAGE_TAG can be passed as an environment variable or as a file input located at `./eq-survey-runner-benchmark-image/tag`.
 
@@ -45,7 +44,6 @@ USER_WAIT_TIME_MAX_SECONDS=<user_max_wait_time> \
 PARALLELISM=<number_of_jobs_to_run> \
 TIMEOUT=<job_timeout> \
 OUTPUT_DIR=<folder_where_outputs_are_stored> \
-OUTPUT_BUCKET=<bucket_where_outputs_are_stored> \
 fly -t census-eq execute \
   --config ci/run_benchmark.yaml \
   -v image_registry=<docker-registry> \
@@ -55,11 +53,11 @@ fly -t census-eq execute \
 ## Output results to Slack
 The following env vars must be set:
 
-- OUTPUT_BUCKET
 - OUTPUT_DIR
 - SLACK_CHANNEL_NAME
 
 The following env var already has a sensible default, but can be set with an alternative value if needed:
+- OUTPUT_BUCKET
 - SLACK_AUTH_TOKEN
 - NUMBER_OF_DAYS
 
@@ -67,7 +65,6 @@ The following env var already has a sensible default, but can be set with an alt
 Use the `fly execute` command to run the task.
 
 ```sh
-OUTPUT_BUCKET=<output_bucket_name> \
 OUTPUT_DIR=<output_directory> \
 SLACK_CHANNEL_NAME=<slack_channel_name> \
 fly -t census-eq execute \

--- a/ci/run-benchmark.yaml
+++ b/ci/run-benchmark.yaml
@@ -21,7 +21,6 @@ params:
   PARALLELISM:
   TIMEOUT:
   OUTPUT_DIR:
-  OUTPUT_BUCKET:
   SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
 run:
   path: bash
@@ -55,7 +54,7 @@ run:
         --set userWaitTimeMinSeconds=${USER_WAIT_TIME_MIN_SECONDS} \
         --set userWaitTimeMaxSeconds=${USER_WAIT_TIME_MAX_SECONDS} \
         --set parallelism=${PARALLELISM} \
-        --set output.bucket=${OUTPUT_BUCKET} \
+        --set output.bucket="${PROJECT_ID}-outputs" \
         --set output.directory="${OUTPUT_DIR}/${RUNTIME_DATE_STRING}"
 
       JOB_NAME=$(kubectl get jobs '--output=jsonpath={.items[*].metadata.name}')


### PR DESCRIPTION
### What is the context of this PR?
We wanted to hard code the output_bucket name on creation to "${var.project_id}-benchmark-outputs" in performance testing pipelines so we will pass the Project ID in future only.
Current approach is error prone and can lead to hard to diagnose test's timeouts.

### How to review 
Run one of the benchmarks using [appropriate branch](https://github.com/ONSdigital/eq-pipelines/pull/329) of  eq-pipelines and this branch of benchmark and check if test doesn't time out and outputs to correct bucket, slack channel.


