### PR TITLE
Use eq-benchmark-deploy-image in ci script

### DIFF
--- a/ci/run-benchmark.yaml
+++ b/ci/run-benchmark.yaml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: ((image_registry))/eq-benchmark-deploy-image
+    repository: ((image_registry))/eq-app-k8s-deploy-image
     tag: ((deploy_image_version))
 inputs:
   - name: eq-survey-runner-benchmark

--- a/ci/run-benchmark.yaml
+++ b/ci/run-benchmark.yaml
@@ -2,7 +2,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: ((image_registry))/eq-app-deploy-image
+    repository: ((image_registry))/eq-benchmark-deploy-image
     tag: ((deploy_image_version))
 inputs:
   - name: eq-survey-runner-benchmark


### PR DESCRIPTION
### What is the context of this PR?
This modifies the benchmark ci script to use the app-deploy-image that is created from k8s Dockerfile in eq-app-deploy-image repo. Check the other PRs associated with this change.

[Pipelines PR](https://github.com/ONSdigital/eq-pipelines/pull/355)
[App deploy image PR](https://github.com/ONSdigital/eq-app-deploy-image/pull/4)

### How to review 
This has been checked in [this benchmark](https://concourse.gcp.onsdigital.uk/teams/eq-dev/pipelines/ash-benchmark-daily/jobs/run-benchmark/builds/2).
