### PR TITLE
Set response_expires_at field to Payload

### DIFF
--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -1,7 +1,7 @@
 import os
 import time
 from uuid import uuid4
-
+from datetime import datetime, timedelta
 from sdc.crypto.encrypter import encrypt
 from sdc.crypto.key_store import KeyStore
 
@@ -76,7 +76,7 @@ def _get_payload_with_params(schema_name, schema_url=None, **extra_payload):
     payload_vars['iat'] = time.time()
     payload_vars['exp'] = payload_vars['iat'] + float(3600)  # one hour from now
     payload_vars['jti'] = str(uuid4())
-    payload_vars['response_expires_at'] =  payload_vars['iat'] + float(604800) # 7 days from now which is the default expiry time
+    payload_vars['response_expires_at'] = (datetime.now() + timedelta(days=7)).isoformat() # 7 days from now which is the default expiry time
     for key, value in extra_payload.items():
         payload_vars[key] = value
 

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -76,7 +76,9 @@ def _get_payload_with_params(schema_name, schema_url=None, **extra_payload):
     payload_vars['iat'] = time.time()
     payload_vars['exp'] = payload_vars['iat'] + float(3600)  # one hour from now
     payload_vars['jti'] = str(uuid4())
-    payload_vars['response_expires_at'] = (datetime.now() + timedelta(days=7)).isoformat() # 7 days from now which is the default expiry time
+    payload_vars['response_expires_at'] = (
+        datetime.now() + timedelta(days=7)
+    ).isoformat()  # 7 days from now which is the default expiry time
     for key, value in extra_payload.items():
         payload_vars[key] = value
 

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -76,7 +76,7 @@ def _get_payload_with_params(schema_name, schema_url=None, **extra_payload):
     payload_vars['iat'] = time.time()
     payload_vars['exp'] = payload_vars['iat'] + float(3600)  # one hour from now
     payload_vars['jti'] = str(uuid4())
-
+    payload_vars['response_expires_at'] =  payload_vars['iat'] + float(3600)
     for key, value in extra_payload.items():
         payload_vars[key] = value
 

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -76,7 +76,7 @@ def _get_payload_with_params(schema_name, schema_url=None, **extra_payload):
     payload_vars['iat'] = time.time()
     payload_vars['exp'] = payload_vars['iat'] + float(3600)  # one hour from now
     payload_vars['jti'] = str(uuid4())
-    payload_vars['response_expires_at'] =  payload_vars['iat'] + float(10080) # 7 days from now which is the default expiry time
+    payload_vars['response_expires_at'] =  payload_vars['iat'] + float(604800) # 7 days from now which is the default expiry time
     for key, value in extra_payload.items():
         payload_vars[key] = value
 

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -1,7 +1,7 @@
 import os
 import time
 from uuid import uuid4
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from sdc.crypto.encrypter import encrypt
 from sdc.crypto.key_store import KeyStore
 

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -76,7 +76,7 @@ def _get_payload_with_params(schema_name, schema_url=None, **extra_payload):
     payload_vars['iat'] = time.time()
     payload_vars['exp'] = payload_vars['iat'] + float(3600)  # one hour from now
     payload_vars['jti'] = str(uuid4())
-    payload_vars['response_expires_at'] =  payload_vars['iat'] + float(3600)
+    payload_vars['response_expires_at'] =  payload_vars['iat'] + float(10080) # 7 days from now which is the default expiry time
     for key, value in extra_payload.items():
         payload_vars[key] = value
 

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -78,7 +78,6 @@ def _get_payload_with_params(schema_name, schema_url=None, **extra_payload):
     payload_vars['jti'] = str(uuid4())
     payload_vars['response_expires_at'] = (
         datetime.now(tz=timezone.utc) + timedelta(days=7)
-```
     ).isoformat()  # 7 days from now in ISO 8601 format
     for key, value in extra_payload.items():
         payload_vars[key] = value

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -78,7 +78,7 @@ def _get_payload_with_params(schema_name, schema_url=None, **extra_payload):
     payload_vars['jti'] = str(uuid4())
     payload_vars['response_expires_at'] = (
         datetime.now() + timedelta(days=7)
-    ).isoformat()  # 7 days from now which is the default expiry time
+    ).isoformat()  # 7 days from now in ISO 8601 format
     for key, value in extra_payload.items():
         payload_vars[key] = value
 

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -77,7 +77,8 @@ def _get_payload_with_params(schema_name, schema_url=None, **extra_payload):
     payload_vars['exp'] = payload_vars['iat'] + float(3600)  # one hour from now
     payload_vars['jti'] = str(uuid4())
     payload_vars['response_expires_at'] = (
-        datetime.now() + timedelta(days=7)
+        datetime.now(tz=timezone.utc) + timedelta(days=7)
+```
     ).isoformat()  # 7 days from now in ISO 8601 format
     for key, value in extra_payload.items():
         payload_vars[key] = value


### PR DESCRIPTION
### What is the context of this PR?
This PR is to fix the benchmark failures that are occurring because datastore jobs are removing "live" entities. We are adding the `response_expires_at` field which is defaulted value is 7 days from the current time to solve the issue.

### How to review
1. Run benchmark locally
2. Then deploy it on concourse and check if any errors occur

Is the way the time is calculated and formatted understandable? 