### PR TITLE
Migrate from docker-image to registry-image

### DIFF
--- a/ci/output-results-to-slack.yaml
+++ b/ci/output-results-to-slack.yaml
@@ -1,6 +1,6 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: python
     tag: 3.11-slim

--- a/ci/run-benchmark.yaml
+++ b/ci/run-benchmark.yaml
@@ -1,6 +1,6 @@
 platform: linux
 image_resource:
-  type: docker-image
+  type: registry-image
   source:
     repository: ((image_registry))/eq-app-k8s-deploy-image
     tag: ((deploy_image_version))


### PR DESCRIPTION
### What is the context of this PR?
Updates tasks to use `registry-image` rather than `docker-image`

### How to review
Deploy the benchmark pipeline and check that it is still working
