### PR TITLE
Update payload to v2 layout to run daily benchmark

### DIFF
--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -14,25 +14,27 @@ SR_USER_AUTHENTICATION_PUBLIC_KEY_KID = 'e19091072f920cbf3ca9f436ceba309e7d814a6
 KEYS_FOLDER = './jwt-test-keys'
 
 PAYLOAD = {
-    'user_id': 'benchmark-user',
-    'period_str': 'July 2019',
-    'period_id': '201907',
-    'collection_exercise_sid': str(uuid4()),
-    'case_id': str(uuid4()),
-    'case_type': 'HI',
-    'display_address': '68 Abingdon Road, Goathill',
-    'ru_ref': '123456789012A',
-    'ru_name': 'Integration Testing',
-    'ref_p_start_date': '2019-04-01',
-    'ref_p_end_date': '2019-11-30',
-    'return_by': '2019-12-06',
-    'trad_as': 'Benchmark Tests',
-    'employment_date': '1983-06-02',
-    'region_code': 'GB-ENG',
-    'language_code': 'en',
-    'roles': [],
+    'version': 'v2',
     'account_service_url': 'http://upstream.url',
-    'variant_flags': {'sexual_identity': 'false'},
+    'case_id': str(uuid4()),
+    'collection_exercise_sid': str(uuid4()),
+    'response_id': str(uuid4()),
+    "survey_metadata": {
+        "data": {
+            "case_ref": '1000000000000001',
+            "form_type": '0001',
+            'period_id': '201907',
+            'period_str': 'July 2019',
+            'ref_p_start_date': '2019-04-01',
+            'ref_p_end_date': '2019-11-30',
+            'ru_name': 'Integration Testing',
+            'ru_ref': '123456789012A',
+            'trad_as': 'Benchmark Tests',
+            'user_id': 'benchmark-user',
+            'survey_id': "0",
+            "employment_date": "2019-04-01",
+        }
+    },
 }
 
 
@@ -81,7 +83,7 @@ def _get_payload_with_params(schema_name, schema_url=None, **extra_payload):
         datetime.now(tz=timezone.utc) + timedelta(days=7)
     ).isoformat()  # 7 days from now in ISO 8601 format
     for key, value in extra_payload.items():
-        payload_vars[key] = value
+        payload_vars["survey_metadata"]["data"][key] = value
 
     return payload_vars
 

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -49,7 +49,7 @@ PAYLOAD = {
             'period_str': 'July 2019',
             'ref_p_start_date': '2019-04-01',
             'ref_p_end_date': '2019-11-30',
-            'ru_name': 'Integration Testing',
+            'ru_name': 'Benchmark Testing',
             'ru_ref': '123456789012A',
             'trad_as': 'Benchmark Tests',
             'display_address': '68 Abingdon Road, Goathill',

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -13,12 +13,35 @@ SR_USER_AUTHENTICATION_PUBLIC_KEY_KID = 'e19091072f920cbf3ca9f436ceba309e7d814a6
 
 KEYS_FOLDER = './jwt-test-keys'
 
+# "version" is excluded here as it is handled independently
+TOP_LEVEL_METADATA_KEYS = [
+    "exp",
+    "jti",
+    "iat",
+    "tx_id",
+    "account_service_url",
+    "case_id",
+    "collection_exercise_sid",
+    "response_id",
+    "response_expires_at",
+    "language_code",
+    "schema_name",
+    "schema_url",
+    "cir_instrument_id",
+    "channel",
+    "region_code",
+    "roles",
+]
+
 PAYLOAD = {
     'version': 'v2',
     'account_service_url': 'http://upstream.url',
     'case_id': str(uuid4()),
     'collection_exercise_sid': str(uuid4()),
     'response_id': str(uuid4()),
+    'language_code': 'en',
+    'region_code': 'GB-ENG',
+    'roles': [],
     'survey_metadata': {
         'data': {
             'case_ref': '1000000000000001',
@@ -82,8 +105,12 @@ def _get_payload_with_params(schema_name, schema_url=None, **extra_payload):
     payload_vars['response_expires_at'] = (
         datetime.now(tz=timezone.utc) + timedelta(days=7)
     ).isoformat()  # 7 days from now in ISO 8601 format
+
     for key, value in extra_payload.items():
-        payload_vars['survey_metadata']['data'][key] = value
+        if key in TOP_LEVEL_METADATA_KEYS:
+            payload_vars[key] = value
+        else:
+            payload_vars['survey_metadata']['data'][key] = value
 
     return payload_vars
 

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -13,7 +13,6 @@ SR_USER_AUTHENTICATION_PUBLIC_KEY_KID = 'e19091072f920cbf3ca9f436ceba309e7d814a6
 
 KEYS_FOLDER = './jwt-test-keys'
 
-# "version" is excluded here as it is handled independently
 TOP_LEVEL_METADATA_KEYS = [
     "exp",
     "jti",
@@ -53,6 +52,7 @@ PAYLOAD = {
             'ru_name': 'Integration Testing',
             'ru_ref': '123456789012A',
             'trad_as': 'Benchmark Tests',
+            'display_address': '68 Abingdon Road, Goathill',
             'user_id': 'benchmark-user',
             'survey_id': '0',
             'employment_date': '2019-04-01',

--- a/runner_benchmark/token_generator.py
+++ b/runner_benchmark/token_generator.py
@@ -19,10 +19,10 @@ PAYLOAD = {
     'case_id': str(uuid4()),
     'collection_exercise_sid': str(uuid4()),
     'response_id': str(uuid4()),
-    "survey_metadata": {
-        "data": {
-            "case_ref": '1000000000000001',
-            "form_type": '0001',
+    'survey_metadata': {
+        'data': {
+            'case_ref': '1000000000000001',
+            'form_type': '0001',
             'period_id': '201907',
             'period_str': 'July 2019',
             'ref_p_start_date': '2019-04-01',
@@ -31,8 +31,8 @@ PAYLOAD = {
             'ru_ref': '123456789012A',
             'trad_as': 'Benchmark Tests',
             'user_id': 'benchmark-user',
-            'survey_id': "0",
-            "employment_date": "2019-04-01",
+            'survey_id': '0',
+            'employment_date': '2019-04-01',
         }
     },
 }
@@ -83,7 +83,7 @@ def _get_payload_with_params(schema_name, schema_url=None, **extra_payload):
         datetime.now(tz=timezone.utc) + timedelta(days=7)
     ).isoformat()  # 7 days from now in ISO 8601 format
     for key, value in extra_payload.items():
-        payload_vars["survey_metadata"]["data"][key] = value
+        payload_vars['survey_metadata']['data'][key] = value
 
     return payload_vars
 


### PR DESCRIPTION
### What is the context of this PR?
The daily benchmark needs to be updated to use the `v2` schema launch payload format to allow a successful run, following a recent Runner change to remove all traces of the `v1` schema launch.

The payload has now been altered to align with the example `v2` schema found in the [ons-schema-definitions](https://github.com/ONSdigital/ons-schema-definitions/blob/main/examples/rm_to_eq_runner/payload_v2/launch_jwt_business.json) repo (excluding the `sds_dataset_id`)

### How to review
Run the below benchmarks from this repo root, they should now run successfully. A follow-up ticket will be raised to investigate possibly removing the other JSON requests, as some appear to no longer be in use:

- `pipenv run ./run.sh requests/test_benchmark_business_happy_path.json`
- `pipenv run ./run.sh requests/test_benchmark_business_unhappy_path.json`
- `pipenv run ./run.sh requests/test_checkbox.json`

[Jira](https://jira.ons.gov.uk/browse/ECI-1254)