### PR TITLE
EQS-512 - Fix incorrect link in recent Spike doc

### DIFF
--- a/doc/performance-investigations/0025-pdfkit-alternatives/summary.md
+++ b/doc/performance-investigations/0025-pdfkit-alternatives/summary.md
@@ -3,7 +3,7 @@
 Important notes:
 
 * This investigation aims to repeat the previous investigation
-  in [Investigation 0021](../0021-pdfkit-vs-weasyprint/summary.md), but now uses the new 'happy path' benchmark journey
+  in [0018](../0018-pdf-weasyprint-pdfkit/summary.md), but now uses the new 'happy path' benchmark journey
   which includes the `/download-pdf` end point, along with the latest updates of dependencies and Runner.
 * The benchmarks are very much a 'worst case scenario' because the journey _always_ hits the `/download-pdf` endpoint.
   In reality, not all users will download the PDF, so the overall impact on performance may be less significant.


### PR DESCRIPTION
### What is the context of this PR?
Now points to the correct doc link for the previous spike

### How to review
Check that the link works